### PR TITLE
Fix Coverage Reports missing in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
       }
       post {
         always {
-          sh '[ -d server/target/site ] && cd server/target/site && zip -r coverage-server.zip jacoco && cd -; exit 0'
+          sh '[ -d target/site ] && cd target/site && zip -r coverage.zip jacoco && cd -; exit 0'
           junit(testResults: '**/target/surefire-reports/*.xml', allowEmptyResults: true)
           archiveArtifacts allowEmptyArchive: true, artifacts: '**/target/site/*.zip'
         }


### PR DESCRIPTION
I forgot to change this in #3.

Jenkins should now collect the coverage reports created by jacoco properly