### PR TITLE
Fixed Bug with Fn class

### DIFF
--- a/src/main/java/com/scaleset/cfbuilder/core/Fn.java
+++ b/src/main/java/com/scaleset/cfbuilder/core/Fn.java
@@ -1,12 +1,13 @@
 package com.scaleset.cfbuilder.core;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 public class Fn {
 
@@ -26,19 +27,14 @@ public class Fn {
         properties.put("Fn::" + name, parameters);
     }
 
-    public Fn(String name, String delimiter, Object... params) {
-        this.name = name;
-        List<Object> list = new ArrayList();
-        for (Object param : params) {
-            list.add(param);
-        }
-        parameters.add(delimiter);
-        parameters.add(list);
-        properties.put("Fn::" + name, parameters);
-    }
 
     public static Fn fn(String name, Object... params) {
         return new Fn(name, params);
+    }
+
+    public static Fn fnDelimiter(String name, String delimiter, Object... params){
+        List<Object> list = Arrays.asList(params);
+        return new Fn(name, delimiter, list);
     }
 
     @JsonAnyGetter

--- a/src/test/java/com/scaleset/cfbuilder/MetadataTest.java
+++ b/src/test/java/com/scaleset/cfbuilder/MetadataTest.java
@@ -6,7 +6,13 @@ import com.scaleset.cfbuilder.core.Template;
 import com.scaleset.cfbuilder.ec2.Instance;
 import com.scaleset.cfbuilder.ec2.SecurityGroup;
 import com.scaleset.cfbuilder.ec2.UserData;
-import com.scaleset.cfbuilder.ec2.metadata.*;
+import com.scaleset.cfbuilder.ec2.metadata.CFNCommand;
+import com.scaleset.cfbuilder.ec2.metadata.CFNFile;
+import com.scaleset.cfbuilder.ec2.metadata.CFNInit;
+import com.scaleset.cfbuilder.ec2.metadata.CFNPackage;
+import com.scaleset.cfbuilder.ec2.metadata.CFNService;
+import com.scaleset.cfbuilder.ec2.metadata.Config;
+import com.scaleset.cfbuilder.ec2.metadata.SimpleService;
 import org.junit.Test;
 
 import static org.junit.Assert.assertNotNull;
@@ -78,8 +84,7 @@ public class MetadataTest {
                     .instanceType("t2.micro")
                     .securityGroupIds(webServerSecurityGroup)
                     .keyName(keyNameVar)
-                    .userData(new UserData(new Fn("Join", "", "eins", "zwei")));
-
+                    .userData(new UserData(Fn.fnDelimiter("Join", "", "eins", "zwei")));
 
             Object publicDNSName = webServerInstance.fnGetAtt("PublicDnsName");
 


### PR DESCRIPTION
Fixed bug where Fn didn't work with GetAtt because the first String would be taken as delimiter.
Now there is a static function for creating Fns with delimiters