### PR TITLE
Add full support for AWS::EC2::Instance, AWS::EC2::NetworkInterface, AWS::EC2::Volume

### DIFF
--- a/src/main/java/com/scaleset/cfbuilder/autoscaling/AutoScalingGroup.java
+++ b/src/main/java/com/scaleset/cfbuilder/autoscaling/AutoScalingGroup.java
@@ -6,7 +6,12 @@ import com.scaleset.cfbuilder.annotations.Type;
 import com.scaleset.cfbuilder.core.Resource;
 import com.scaleset.cfbuilder.core.Taggable;
 
+/**
+ Constructs a {@code AutoScalingGroup} to create an Auto Scaling group.
+ <br>
+ Type: {@code AWS::AutoScaling::AutoScalingGroup}
 
+ @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html">Documentation Reference</a> */
 @Type("AWS::AutoScaling::AutoScalingGroup")
 public interface AutoScalingGroup extends Taggable {
 

--- a/src/main/java/com/scaleset/cfbuilder/autoscaling/LaunchConfiguration.java
+++ b/src/main/java/com/scaleset/cfbuilder/autoscaling/LaunchConfiguration.java
@@ -1,4 +1,12 @@
 package com.scaleset.cfbuilder.autoscaling;
 
+import com.scaleset.cfbuilder.ec2.Instance;
+
+/**
+ Constructs a {@code LaunchConfiguration} to create an Auto Scaling launch configuration that can be used by an {@link AutoScalingGroup} to configure Amazon EC2 {@link Instance}s in the Auto Scaling group.
+ <br>
+ Type: {@code AWS::AutoScaling::LaunchConfiguration}
+
+ @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html">Documentation Reference</a> */
 public interface LaunchConfiguration {
 }

--- a/src/main/java/com/scaleset/cfbuilder/cloudformation/Authentication.java
+++ b/src/main/java/com/scaleset/cfbuilder/cloudformation/Authentication.java
@@ -35,12 +35,12 @@ public class Authentication {
     private String name;
 
     /**
-     Constructs an <tt>Authentication<tt> to specify authentication credentials for files or sources specified
-     with the <tt>AWS::CloudFormation::Init<tt> resource.
-     Type: <tt>AWS::CloudFormation::Authentication<tt>
-     Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-authentication.html
+     Constructs an {@code Authentication{@code  to specify authentication credentials for files or sources specified
+     with the {@code AWS::CloudFormation::Init{@code  resource.
+     Type: {@code AWS::CloudFormation::Authentication{@code
+     @see <a href=" https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-authentication.html
 
-     @param name of this <tt>Authentication<tt>
+     @param name of this {@code Authentication{@code
      */
     public Authentication(String name) {
         this.name = name;

--- a/src/main/java/com/scaleset/cfbuilder/cloudformation/Authentication.java
+++ b/src/main/java/com/scaleset/cfbuilder/cloudformation/Authentication.java
@@ -6,7 +6,14 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.scaleset.cfbuilder.annotations.Type;
+import com.scaleset.cfbuilder.ec2.metadata.CFNInit;
 
+/**
+ Constructs an {@code Authentication} to specify authentication credentials for files or sources specified with the {@link CFNInit} resource.
+ <br>
+ Type: {@code AWS::CloudFormation::Authentication}
+
+ @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-authentication.html>Documentation Reference</a> */
 @Type("AWS::CloudFormation::Authentication")
 public class Authentication {
 
@@ -34,14 +41,6 @@ public class Authentication {
     @JsonIgnore
     private String name;
 
-    /**
-     Constructs an {@code Authentication{@code  to specify authentication credentials for files or sources specified
-     with the {@code AWS::CloudFormation::Init{@code  resource.
-     Type: {@code AWS::CloudFormation::Authentication{@code
-     @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-authentication.html
-
-     @param name of this {@code Authentication{@code
-     */
     public Authentication(String name) {
         this.name = name;
         this.buckets = new ArrayList<>();

--- a/src/main/java/com/scaleset/cfbuilder/cloudformation/Authentication.java
+++ b/src/main/java/com/scaleset/cfbuilder/cloudformation/Authentication.java
@@ -38,7 +38,7 @@ public class Authentication {
      Constructs an {@code Authentication{@code  to specify authentication credentials for files or sources specified
      with the {@code AWS::CloudFormation::Init{@code  resource.
      Type: {@code AWS::CloudFormation::Authentication{@code
-     @see <a href=" https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-authentication.html
+     @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-authentication.html
 
      @param name of this {@code Authentication{@code
      */

--- a/src/main/java/com/scaleset/cfbuilder/core/Template.java
+++ b/src/main/java/com/scaleset/cfbuilder/core/Template.java
@@ -65,6 +65,14 @@ public class Template {
         this.version = version;
     }
 
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
     public Parameter numParam(String id) {
         Parameter result = new Parameter().id(id).type("Number");
         parameters.put(id, result);

--- a/src/main/java/com/scaleset/cfbuilder/ec2/Eip.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/Eip.java
@@ -3,6 +3,12 @@ package com.scaleset.cfbuilder.ec2;
 import com.scaleset.cfbuilder.annotations.Type;
 import com.scaleset.cfbuilder.core.Resource;
 
+/**
+ Constructs an {@code Eip} to allocate an Elastic IP (EIP) address and optionally, associate it with an Amazon EC2 {@link Instance}.
+ <br>
+ Type: {@code AWS::EC2::EIP}
+
+ @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-eip.html">Documentation Reference</a> */
 @Type("AWS::EC2::EIP")
 public interface Eip extends Resource {
 

--- a/src/main/java/com/scaleset/cfbuilder/ec2/EipAssociation.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/EipAssociation.java
@@ -4,7 +4,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.scaleset.cfbuilder.annotations.Type;
 import com.scaleset.cfbuilder.core.Resource;
 
-@Type("EIPAssociation")
+/**
+ Constructs an {@code EipAssociation} to associate an Elastic IP address with an Amazon EC2 {@link Instance}.
+ <br>
+ Type: {@code AWS::EC2::EIPAssociation}
+
+ @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-eip-association.html">Documentation Reference</a> */
+@Type("AWS::EC2::EIPAssociation")
 public interface EipAssociation {
 
     EipAssociation allocationId(Object value);
@@ -16,5 +22,4 @@ public interface EipAssociation {
     EipAssociation NetworkInterfaceId(Object value);
 
     EipAssociation privateIpAddress(Object value);
-
 }

--- a/src/main/java/com/scaleset/cfbuilder/ec2/EipAssociation.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/EipAssociation.java
@@ -1,6 +1,5 @@
 package com.scaleset.cfbuilder.ec2;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.scaleset.cfbuilder.annotations.Type;
 import com.scaleset.cfbuilder.core.Resource;
 
@@ -11,15 +10,15 @@ import com.scaleset.cfbuilder.core.Resource;
 
  @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-eip-association.html">Documentation Reference</a> */
 @Type("AWS::EC2::EIPAssociation")
-public interface EipAssociation {
+public interface EipAssociation extends Resource {
 
     EipAssociation allocationId(Object value);
 
-    EipAssociation EIP(Object value);
+    EipAssociation eIP(Object value);
 
     EipAssociation instanceId(Object value);
 
-    EipAssociation NetworkInterfaceId(Object value);
+    EipAssociation networkInterfaceId(Object value);
 
     EipAssociation privateIpAddress(Object value);
 }

--- a/src/main/java/com/scaleset/cfbuilder/ec2/Instance.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/Instance.java
@@ -17,7 +17,7 @@ import com.scaleset.cfbuilder.ec2.networkinterface.Ipv6Address;
  <br>
  Type: {@code AWS::EC2::Instance}
 
- @see <a href=" https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html">Documentation Reference</a> */
+ @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html">Documentation Reference</a> */
 @Type("AWS::EC2::Instance")
 public interface Instance extends Taggable {
 

--- a/src/main/java/com/scaleset/cfbuilder/ec2/Instance.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/Instance.java
@@ -13,10 +13,11 @@ import com.scaleset.cfbuilder.ec2.metadata.CFNInit;
 import com.scaleset.cfbuilder.ec2.networkinterface.Ipv6Address;
 
 /**
- Constructs an EC2 <tt>Instance</tt>.
- Type: </tt>AWS::EC2::Instance</tt>
- Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html
- */
+ Constructs an EC2 {@code Instance}.
+ <br>
+ Type: {@code AWS::EC2::Instance}
+
+ @see <a href=" https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html">Documentation Reference</a> */
 @Type("AWS::EC2::Instance")
 public interface Instance extends Taggable {
 

--- a/src/main/java/com/scaleset/cfbuilder/ec2/Instance.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/Instance.java
@@ -53,7 +53,7 @@ public interface Instance extends Taggable {
 
     Instance keyName(Object value);
 
-    Instance monitoring(boolean value);
+    Instance monitoring(Boolean value);
 
     Instance networkInterfaces(EC2NetworkInterface... values);
 
@@ -67,7 +67,7 @@ public interface Instance extends Taggable {
 
     Instance securityGroups(Object... values);
 
-    Instance sourceDestCheck(boolean value);
+    Instance sourceDestCheck(Boolean value);
 
     Instance ssmAssociations(SSMAssociation... values);
 

--- a/src/main/java/com/scaleset/cfbuilder/ec2/Instance.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/Instance.java
@@ -3,38 +3,90 @@ package com.scaleset.cfbuilder.ec2;
 import com.scaleset.cfbuilder.annotations.Type;
 import com.scaleset.cfbuilder.cloudformation.Authentication;
 import com.scaleset.cfbuilder.core.Taggable;
+import com.scaleset.cfbuilder.ec2.instance.CreditSpecification;
+import com.scaleset.cfbuilder.ec2.instance.EC2BlockDeviceMapping;
+import com.scaleset.cfbuilder.ec2.instance.EC2MountPoint;
+import com.scaleset.cfbuilder.ec2.instance.EC2NetworkInterface;
+import com.scaleset.cfbuilder.ec2.instance.ElasticGpuSpecification;
+import com.scaleset.cfbuilder.ec2.instance.SSMAssociation;
 import com.scaleset.cfbuilder.ec2.metadata.CFNInit;
+import com.scaleset.cfbuilder.ec2.networkinterface.Ipv6Address;
 
+/**
+ Constructs an EC2 <tt>Instance</tt>.
+ Type: </tt>AWS::EC2::Instance</tt>
+ Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html
+ */
 @Type("AWS::EC2::Instance")
 public interface Instance extends Taggable {
 
-    Instance availabilityZone(Object... values);
+    Instance affinity(Object value);
 
-    Instance instanceType(Object value);
+    Instance availabilityZone(Object value);
+
+    Instance blockDeviceMappings(EC2BlockDeviceMapping... values);
+
+    Instance creditSpecification(CreditSpecification value);
+
+    Instance disableApiTermination(Boolean value);
+
+    Instance ebsOptimized(Boolean value);
+
+    Instance elasticGpuSpecifications(ElasticGpuSpecification... values);
+
+    Instance hostId(Object value);
+
+    Instance iamInstanceProfile(Object value);
 
     Instance imageId(Object value);
 
-    Instance instanceProfile(Object value);
+    Instance instanceInitiatedShutdownBehavior(Object value);
+
+    Instance instanceType(Object value);
+
+    Instance ipv6AddressCount(int value);
+
+    Instance ipv6Addresses(Ipv6Address... values);
+
+    Instance kernelId(Object value);
 
     Instance keyName(Object value);
 
+    Instance monitoring(boolean value);
+
+    Instance networkInterfaces(EC2NetworkInterface... values);
+
+    Instance placementGroupName(Object value);
+
+    Instance privateIpAddress(Object value);
+
+    Instance ramdiskId(Object value);
+
     Instance securityGroupIds(Object... values);
+
+    Instance securityGroups(Object... values);
+
+    Instance sourceDestCheck(boolean value);
+
+    Instance ssmAssociations(SSMAssociation... values);
 
     Instance subnetId(Object subnetId);
 
+    Instance tenancy(Object value);
+
     Instance userData(UserData userData);
 
-    // non property additions
+    Instance volumes(EC2MountPoint... values);
 
+    Instance additionalInfo(Object value);
 
     default Instance name(String name) {
         tag("Name", name);
         return this;
     }
 
+    // Non property additions
     Instance addCFNInit(CFNInit cfnInit);
-
-    Instance iamInstanceProfile (Object value);
 
     Instance authentication(Authentication authentication);
 }

--- a/src/main/java/com/scaleset/cfbuilder/ec2/Instance.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/Instance.java
@@ -45,7 +45,7 @@ public interface Instance extends Taggable {
 
     Instance instanceType(Object value);
 
-    Instance ipv6AddressCount(int value);
+    Instance ipv6AddressCount(Integer value);
 
     Instance ipv6Addresses(Ipv6Address... values);
 

--- a/src/main/java/com/scaleset/cfbuilder/ec2/NetworkInterface.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/NetworkInterface.java
@@ -6,10 +6,11 @@ import com.scaleset.cfbuilder.ec2.networkinterface.Ipv6Address;
 import com.scaleset.cfbuilder.ec2.networkinterface.PrivateIpAddressSpecification;
 
 /**
- Describes a <tt>NetworkInterfact</tt> in an EC2 instance. Provided in a list in the NetworkInterfaces property of <tt>AWS::EC2::Instance</tt>.
- Type: <tt>AWS::EC2::NetworkInterface</tt>
- Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-interface.html
- */
+ Describes a {@code NetworkInterface} in an EC2 instance. Provided in a list in the NetworkInterfaces property of EC2 {@link Instance}.
+ <br>
+ Type: {@code AWS::EC2::NetworkInterface}
+
+ @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-interface.html">Documentation Reference</a> */
 @Type("")
 public interface NetworkInterface extends Taggable {
 

--- a/src/main/java/com/scaleset/cfbuilder/ec2/NetworkInterface.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/NetworkInterface.java
@@ -28,7 +28,7 @@ public interface NetworkInterface extends Taggable {
 
     NetworkInterface secondaryPrivateIpAddressCount(int value);
 
-    NetworkInterface sourceDestCheck(boolean value);
+    NetworkInterface sourceDestCheck(Boolean value);
 
     NetworkInterface subnetId(Object value);
 

--- a/src/main/java/com/scaleset/cfbuilder/ec2/NetworkInterface.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/NetworkInterface.java
@@ -1,0 +1,33 @@
+package com.scaleset.cfbuilder.ec2;
+
+import com.scaleset.cfbuilder.annotations.Type;
+import com.scaleset.cfbuilder.core.Taggable;
+import com.scaleset.cfbuilder.ec2.networkinterface.Ipv6Address;
+import com.scaleset.cfbuilder.ec2.networkinterface.PrivateIpAddressSpecification;
+
+/**
+ Describes a <tt>NetworkInterfact</tt> in an EC2 instance. Provided in a list in the NetworkInterfaces property of <tt>AWS::EC2::Instance</tt>.
+ Type: <tt>AWS::EC2::NetworkInterface</tt>
+ Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-interface.html
+ */
+@Type("")
+public interface NetworkInterface extends Taggable {
+
+    NetworkInterface description(Object value);
+
+    NetworkInterface groupSet(Object... values);
+
+    NetworkInterface ipv6AddressCount(int value);
+
+    NetworkInterface ipv6Addresses(Ipv6Address... values);
+
+    NetworkInterface privateIpAddress(Object value);
+
+    NetworkInterface privateIpAddresses(PrivateIpAddressSpecification... values);
+
+    NetworkInterface secondaryPrivateIpAddressCount(int value);
+
+    NetworkInterface sourceDestCheck(boolean value);
+
+    NetworkInterface subnetId(Object value);
+}

--- a/src/main/java/com/scaleset/cfbuilder/ec2/NetworkInterface.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/NetworkInterface.java
@@ -31,4 +31,9 @@ public interface NetworkInterface extends Taggable {
     NetworkInterface sourceDestCheck(boolean value);
 
     NetworkInterface subnetId(Object value);
+
+    default NetworkInterface name(String name) {
+        tag("Name", name);
+        return this;
+    }
 }

--- a/src/main/java/com/scaleset/cfbuilder/ec2/NetworkInterface.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/NetworkInterface.java
@@ -18,7 +18,7 @@ public interface NetworkInterface extends Taggable {
 
     NetworkInterface groupSet(Object... values);
 
-    NetworkInterface ipv6AddressCount(int value);
+    NetworkInterface ipv6AddressCount(Integer value);
 
     NetworkInterface ipv6Addresses(Ipv6Address... values);
 
@@ -26,7 +26,7 @@ public interface NetworkInterface extends Taggable {
 
     NetworkInterface privateIpAddresses(PrivateIpAddressSpecification... values);
 
-    NetworkInterface secondaryPrivateIpAddressCount(int value);
+    NetworkInterface secondaryPrivateIpAddressCount(Integer value);
 
     NetworkInterface sourceDestCheck(Boolean value);
 

--- a/src/main/java/com/scaleset/cfbuilder/ec2/NetworkInterface.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/NetworkInterface.java
@@ -11,7 +11,7 @@ import com.scaleset.cfbuilder.ec2.networkinterface.PrivateIpAddressSpecification
  Type: {@code AWS::EC2::NetworkInterface}
 
  @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-interface.html">Documentation Reference</a> */
-@Type("")
+@Type("AWS::EC2::NetworkInterface")
 public interface NetworkInterface extends Taggable {
 
     NetworkInterface description(Object value);

--- a/src/main/java/com/scaleset/cfbuilder/ec2/SecurityGroup.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/SecurityGroup.java
@@ -5,6 +5,12 @@ import com.scaleset.cfbuilder.core.Resource;
 
 import java.util.function.Consumer;
 
+/**
+ Constructs a {@code SecurityGroup} to create an an Amazon EC2 security group.
+ <br>
+ Type: {@code AWS::EC2::SecurityGroup}
+
+ @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html">Documentation Reference</href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html"> */
 @Type("AWS::EC2::SecurityGroup")
 public interface SecurityGroup extends Resource {
 

--- a/src/main/java/com/scaleset/cfbuilder/ec2/SecurityGroupIngress.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/SecurityGroupIngress.java
@@ -3,6 +3,12 @@ package com.scaleset.cfbuilder.ec2;
 import com.scaleset.cfbuilder.annotations.Type;
 import com.scaleset.cfbuilder.core.Resource;
 
+/**
+ Constructs a {@code SecurityGroupIngress} to add an ingress rule to an Amazon EC2 or Amazon VPC security group.
+ <br>
+ Type: {@code AWS::EC2::SecurityGroupIngress}
+
+ @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group-ingress.html">Documentation Reference</a> */
 @Type("AWS::EC2::SecurityGroupIngress")
 public interface SecurityGroupIngress extends Resource {
 
@@ -35,5 +41,4 @@ public interface SecurityGroupIngress extends Resource {
     SecurityGroupIngress sourceSecurityGroupOwnerId(Object sourceSecurityGroupOwnerId);
 
     SecurityGroupIngress toPort(int toPort);
-
 }

--- a/src/main/java/com/scaleset/cfbuilder/ec2/Subnet.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/Subnet.java
@@ -3,6 +3,12 @@ package com.scaleset.cfbuilder.ec2;
 import com.scaleset.cfbuilder.annotations.Type;
 import com.scaleset.cfbuilder.core.Resource;
 
+/**
+ Constructs a {@code Subnet} to create a subnet in an existing VPC.
+ <br>
+ Type: {@code AWS::EC2::Subnet}
+
+ @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-subnet.html">Documentation Reference</a> */
 @Type("AWS::EC2::Subnet")
 public interface Subnet extends Resource {
 

--- a/src/main/java/com/scaleset/cfbuilder/ec2/UserData.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/UserData.java
@@ -7,6 +7,9 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.scaleset.cfbuilder.core.Fn;
 
+/**
+ Constructs a {@code UserData}, a Base64-encoded MIME user data that is made available to the EC2 {@link Instance}.
+ */
 public class UserData {
 
     @JsonIgnore

--- a/src/main/java/com/scaleset/cfbuilder/ec2/Volume.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/Volume.java
@@ -17,11 +17,11 @@ public interface Volume extends Taggable {
 
     Volume encrypted(Boolean value);
 
-    Volume iops(int value);
+    Volume iops(Integer value);
 
     Volume kmsKeyId(Object value);
 
-    Volume size(int value);
+    Volume size(Integer value);
 
     Volume snapshotId(Object value);
 

--- a/src/main/java/com/scaleset/cfbuilder/ec2/Volume.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/Volume.java
@@ -11,11 +11,11 @@ import com.scaleset.cfbuilder.core.Taggable;
  @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ebs-volume.html">Documentation Reference</a> */
 @Type("AWS::EC2::Volume")
 public interface Volume extends Taggable {
-    Volume autoEnableIO(boolean value);
+    Volume autoEnableIO(Boolean value);
 
     Volume availabilityZone(Object value);
 
-    Volume encrypted(boolean value);
+    Volume encrypted(Boolean value);
 
     Volume iops(int value);
 

--- a/src/main/java/com/scaleset/cfbuilder/ec2/Volume.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/Volume.java
@@ -1,0 +1,34 @@
+package com.scaleset.cfbuilder.ec2;
+
+import com.scaleset.cfbuilder.annotations.Type;
+import com.scaleset.cfbuilder.core.Taggable;
+
+/**
+ Constructs a {@code Volume} to create a new Amazon Elastic Block Store (Amazon EBS) volume.
+ <br>
+ Type: {@code AWS::EC2::Volume}
+
+ @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ebs-volume.html">Documentation Reference</a> */
+@Type("AWS::EC2::Volume")
+public interface Volume extends Taggable {
+    Volume autoEnableIO(boolean value);
+
+    Volume availabilityZone(Object value);
+
+    Volume encrypted(boolean value);
+
+    Volume iops(int value);
+
+    Volume kmsKeyId(Object value);
+
+    Volume size(int value);
+
+    Volume snapshotId(Object value);
+
+    Volume volumeType(Object value);
+
+    default Volume name(String name) {
+        tag("Name", name);
+        return this;
+    }
+}

--- a/src/main/java/com/scaleset/cfbuilder/ec2/Vpc.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/Vpc.java
@@ -3,6 +3,12 @@ package com.scaleset.cfbuilder.ec2;
 import com.scaleset.cfbuilder.annotations.Type;
 import com.scaleset.cfbuilder.core.Resource;
 
+/**
+ Constructs a {@code Vpc} to create a Virtual Private Cloud (VPC).
+ <br>
+ Type: {@code AWS::EC2::VPC}
+
+ @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpc.html">Documentation Reference</a> */
 @Type("AWS::EC2::VPC")
 public interface Vpc extends Resource {
 

--- a/src/main/java/com/scaleset/cfbuilder/ec2/Vpc.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/Vpc.java
@@ -14,9 +14,9 @@ public interface Vpc extends Resource {
 
     Vpc cidrBlock(String cidrBlock);
 
-    Vpc enableDnsSupport(boolean flag);
+    Vpc enableDnsSupport(Boolean flag);
 
-    Vpc enableDnsHostnames(boolean flag);
+    Vpc enableDnsHostnames(Boolean flag);
 
     Vpc instanceTenancy(String instanceTenancy);
 }

--- a/src/main/java/com/scaleset/cfbuilder/ec2/instance/CreditSpecification.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/instance/CreditSpecification.java
@@ -1,10 +1,13 @@
 package com.scaleset.cfbuilder.ec2.instance;
 
+import com.scaleset.cfbuilder.ec2.Instance;
+
 /**
- Constructs a <tt>CreditSpecification</tt> to specify the credit option for CPU usage of a T2 instance.
- Property of the EC2 <tt>Instance</tt> resource.
- Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-creditspecification.html
- */
+ Constructs a {@code CreditSpecification} to specify the credit option for CPU usage of a T2 instance.
+ <br>
+ Property of the EC2 {@link Instance} resource.
+
+ @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-creditspecification.html">Documentation Reference</a> */
 public class CreditSpecification {
     private String cPUCredits;
 

--- a/src/main/java/com/scaleset/cfbuilder/ec2/instance/CreditSpecification.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/instance/CreditSpecification.java
@@ -1,0 +1,23 @@
+package com.scaleset.cfbuilder.ec2.instance;
+
+/**
+ Constructs a <tt>CreditSpecification</tt> to specify the credit option for CPU usage of a T2 instance.
+ Property of the EC2 <tt>Instance</tt> resource.
+ Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-creditspecification.html
+ */
+public class CreditSpecification {
+    private String cPUCredits;
+
+    public String getcPUCredits() {
+        return cPUCredits;
+    }
+
+    public void setcPUCredits(String cPUCredits) {
+        this.cPUCredits = cPUCredits;
+    }
+
+    public CreditSpecification cPUCredits(String cPUCredits) {
+        this.cPUCredits = cPUCredits;
+        return this;
+    }
+}

--- a/src/main/java/com/scaleset/cfbuilder/ec2/instance/EC2BlockDeviceMapping.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/instance/EC2BlockDeviceMapping.java
@@ -1,0 +1,78 @@
+package com.scaleset.cfbuilder.ec2.instance;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.scaleset.cfbuilder.ec2.instance.ec2blockdevicemapping.EC2EBSBlockDevice;
+
+/**
+ Constructs an <tt>EC2BlockDeviceMapping</tt> to be embedded în an <tt>Instance</tt> resource.
+ Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-blockdev-mapping.html
+ */
+public class EC2BlockDeviceMapping {
+    private String deviceName;
+    private List<EC2EBSBlockDevice> ebs;
+    private boolean noDevice;
+    private String virtualName;
+
+    public EC2BlockDeviceMapping(){
+        this.ebs = new ArrayList<>();
+    }
+
+    public String getDeviceName() {
+        return deviceName;
+    }
+
+    public void setDeviceName(String deviceName) {
+        this.deviceName = deviceName;
+    }
+
+    public EC2BlockDeviceMapping deviceName(String deviceName) {
+        this.deviceName = deviceName;
+        return this;
+    }
+
+    public List<EC2EBSBlockDevice> getEbs() {
+        return ebs;
+    }
+
+    public void setEbs(List<EC2EBSBlockDevice> ebs) {
+        this.ebs = ebs;
+    }
+
+    public EC2BlockDeviceMapping ebs(List<EC2EBSBlockDevice> ebs) {
+        this.ebs = ebs;
+        return this;
+    }
+
+    public EC2BlockDeviceMapping addEbs(EC2EBSBlockDevice ebd){
+        this.ebs.add(ebd);
+        return this;
+    }
+
+    public boolean isNoDevice() {
+        return noDevice;
+    }
+
+    public void setNoDevice(boolean noDevice) {
+        this.noDevice = noDevice;
+    }
+
+    public EC2BlockDeviceMapping noDevice(boolean noDevice) {
+        this.noDevice = noDevice;
+        return this;
+    }
+
+    public String getVirtualName() {
+        return virtualName;
+    }
+
+    public void setVirtualName(String virtualName) {
+        this.virtualName = virtualName;
+    }
+
+    public EC2BlockDeviceMapping virtualName(String virtualName) {
+        this.virtualName = virtualName;
+        return this;
+    }
+}

--- a/src/main/java/com/scaleset/cfbuilder/ec2/instance/EC2BlockDeviceMapping.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/instance/EC2BlockDeviceMapping.java
@@ -3,19 +3,20 @@ package com.scaleset.cfbuilder.ec2.instance;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.scaleset.cfbuilder.ec2.Instance;
 import com.scaleset.cfbuilder.ec2.instance.ec2blockdevicemapping.EC2EBSBlockDevice;
 
 /**
- Constructs an <tt>EC2BlockDeviceMapping</tt> to be embedded în an <tt>Instance</tt> resource.
- Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-blockdev-mapping.html
- */
+ Constructs an {@code EC2BlockDeviceMapping} to be embedded în an {@link Instance} resource.
+
+ @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-blockdev-mapping.html">Documentation Reference</a> */
 public class EC2BlockDeviceMapping {
     private String deviceName;
     private List<EC2EBSBlockDevice> ebs;
     private boolean noDevice;
     private String virtualName;
 
-    public EC2BlockDeviceMapping(){
+    public EC2BlockDeviceMapping() {
         this.ebs = new ArrayList<>();
     }
 
@@ -45,7 +46,7 @@ public class EC2BlockDeviceMapping {
         return this;
     }
 
-    public EC2BlockDeviceMapping addEbs(EC2EBSBlockDevice ebd){
+    public EC2BlockDeviceMapping addEbs(EC2EBSBlockDevice ebd) {
         this.ebs.add(ebd);
         return this;
     }

--- a/src/main/java/com/scaleset/cfbuilder/ec2/instance/EC2BlockDeviceMapping.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/instance/EC2BlockDeviceMapping.java
@@ -12,13 +12,9 @@ import com.scaleset.cfbuilder.ec2.instance.ec2blockdevicemapping.EC2EBSBlockDevi
  @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-blockdev-mapping.html">Documentation Reference</a> */
 public class EC2BlockDeviceMapping {
     private String deviceName;
-    private List<EC2EBSBlockDevice> ebs;
+    private EC2EBSBlockDevice ebs;
     private boolean noDevice;
     private String virtualName;
-
-    public EC2BlockDeviceMapping() {
-        this.ebs = new ArrayList<>();
-    }
 
     public String getDeviceName() {
         return deviceName;
@@ -33,21 +29,16 @@ public class EC2BlockDeviceMapping {
         return this;
     }
 
-    public List<EC2EBSBlockDevice> getEbs() {
+    public EC2EBSBlockDevice getEbs() {
         return ebs;
     }
 
-    public void setEbs(List<EC2EBSBlockDevice> ebs) {
+    public void setEbs(EC2EBSBlockDevice ebs) {
         this.ebs = ebs;
     }
 
-    public EC2BlockDeviceMapping ebs(List<EC2EBSBlockDevice> ebs) {
+    public EC2BlockDeviceMapping ebs(EC2EBSBlockDevice ebs) {
         this.ebs = ebs;
-        return this;
-    }
-
-    public EC2BlockDeviceMapping addEbs(EC2EBSBlockDevice ebd) {
-        this.ebs.add(ebd);
         return this;
     }
 

--- a/src/main/java/com/scaleset/cfbuilder/ec2/instance/EC2BlockDeviceMapping.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/instance/EC2BlockDeviceMapping.java
@@ -13,7 +13,7 @@ import com.scaleset.cfbuilder.ec2.instance.ec2blockdevicemapping.EC2EBSBlockDevi
 public class EC2BlockDeviceMapping {
     private String deviceName;
     private EC2EBSBlockDevice ebs;
-    private boolean noDevice;
+    private Boolean noDevice;
     private String virtualName;
 
     public String getDeviceName() {
@@ -42,15 +42,15 @@ public class EC2BlockDeviceMapping {
         return this;
     }
 
-    public boolean isNoDevice() {
+    public Boolean isNoDevice() {
         return noDevice;
     }
 
-    public void setNoDevice(boolean noDevice) {
+    public void setNoDevice(Boolean noDevice) {
         this.noDevice = noDevice;
     }
 
-    public EC2BlockDeviceMapping noDevice(boolean noDevice) {
+    public EC2BlockDeviceMapping noDevice(Boolean noDevice) {
         this.noDevice = noDevice;
         return this;
     }

--- a/src/main/java/com/scaleset/cfbuilder/ec2/instance/EC2MountPoint.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/instance/EC2MountPoint.java
@@ -1,9 +1,11 @@
 package com.scaleset.cfbuilder.ec2.instance;
 
+import com.scaleset.cfbuilder.ec2.Instance;
+
 /**
- Constructs an <tt>EC2MountPoint</tt> to be used as a property of an EC2 <tt>Instance</tt>.
- Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-mount-point.html
- */
+ Constructs an {@code EC2MountPoint} to be used as a property of an EC2 {@link Instance}.
+
+ @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-mount-point.html">Documentation Reference</a> */
 public class EC2MountPoint {
     private String device;
     private String volumeId;

--- a/src/main/java/com/scaleset/cfbuilder/ec2/instance/EC2MountPoint.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/instance/EC2MountPoint.java
@@ -1,0 +1,36 @@
+package com.scaleset.cfbuilder.ec2.instance;
+
+/**
+ Constructs an <tt>EC2MountPoint</tt> to be used as a property of an EC2 <tt>Instance</tt>.
+ Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-mount-point.html
+ */
+public class EC2MountPoint {
+    private String device;
+    private String volumeId;
+
+    public String getDevice() {
+        return device;
+    }
+
+    public void setDevice(String device) {
+        this.device = device;
+    }
+
+    public EC2MountPoint device(String device) {
+        this.device = device;
+        return this;
+    }
+
+    public String getVolumeId() {
+        return volumeId;
+    }
+
+    public void setVolumeId(String volumeId) {
+        this.volumeId = volumeId;
+    }
+
+    public EC2MountPoint volumeId(String volumeId) {
+        this.volumeId = volumeId;
+        return this;
+    }
+}

--- a/src/main/java/com/scaleset/cfbuilder/ec2/instance/EC2NetworkInterface.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/instance/EC2NetworkInterface.java
@@ -17,7 +17,7 @@ public class EC2NetworkInterface {
     private String description;
     private String deviceIndex;
     private List<Object> groupSet;
-    private String networkInterfaceId;
+    private Object networkInterfaceId;
     private Integer ipv6AddressCount;
     private List<Ipv6Address> ipv6Addresses;
     private String privateIpAddress;
@@ -101,15 +101,15 @@ public class EC2NetworkInterface {
         return this;
     }
 
-    public String getNetworkInterfaceId() {
+    public Object getNetworkInterfaceId() {
         return networkInterfaceId;
     }
 
-    public void setNetworkInterfaceId(String networkInterfaceId) {
+    public void setNetworkInterfaceId(Object networkInterfaceId) {
         this.networkInterfaceId = networkInterfaceId;
     }
 
-    public EC2NetworkInterface networkInterfaceId(String networkInterfaceId) {
+    public EC2NetworkInterface networkInterfaceId(Object networkInterfaceId) {
         this.networkInterfaceId = networkInterfaceId;
         return this;
     }

--- a/src/main/java/com/scaleset/cfbuilder/ec2/instance/EC2NetworkInterface.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/instance/EC2NetworkInterface.java
@@ -12,8 +12,8 @@ import com.scaleset.cfbuilder.ec2.networkinterface.PrivateIpAddressSpecification
 
  @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-network-iface-embedded.html">Documentation Reference</a> */
 public class EC2NetworkInterface {
-    private boolean associatePublicIpAddress;
-    private boolean deleteOnTermination;
+    private Boolean associatePublicIpAddress;
+    private Boolean deleteOnTermination;
     private String description;
     private String deviceIndex;
     private List<String> groupSet;
@@ -31,28 +31,28 @@ public class EC2NetworkInterface {
         this.privateIpAddresses = new ArrayList<>();
     }
 
-    public boolean isAssociatePublicIpAddress() {
+    public Boolean isAssociatePublicIpAddress() {
         return associatePublicIpAddress;
     }
 
-    public void setAssociatePublicIpAddress(boolean associatePublicIpAddress) {
+    public void setAssociatePublicIpAddress(Boolean associatePublicIpAddress) {
         this.associatePublicIpAddress = associatePublicIpAddress;
     }
 
-    public EC2NetworkInterface associatePublicIpAddress(boolean associatePublicIpAddress) {
+    public EC2NetworkInterface associatePublicIpAddress(Boolean associatePublicIpAddress) {
         this.associatePublicIpAddress = associatePublicIpAddress;
         return this;
     }
 
-    public boolean isDeleteOnTermination() {
+    public Boolean isDeleteOnTermination() {
         return deleteOnTermination;
     }
 
-    public void setDeleteOnTermination(boolean deleteOnTermination) {
+    public void setDeleteOnTermination(Boolean deleteOnTermination) {
         this.deleteOnTermination = deleteOnTermination;
     }
 
-    public EC2NetworkInterface deleteOnTermination(boolean deleteOnTermination) {
+    public EC2NetworkInterface deleteOnTermination(Boolean deleteOnTermination) {
         this.deleteOnTermination = deleteOnTermination;
         return this;
     }

--- a/src/main/java/com/scaleset/cfbuilder/ec2/instance/EC2NetworkInterface.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/instance/EC2NetworkInterface.java
@@ -3,13 +3,14 @@ package com.scaleset.cfbuilder.ec2.instance;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.scaleset.cfbuilder.ec2.Instance;
 import com.scaleset.cfbuilder.ec2.networkinterface.Ipv6Address;
 import com.scaleset.cfbuilder.ec2.networkinterface.PrivateIpAddressSpecification;
 
 /**
- Constructs a <tt>EC2NetworkInterface</tt> to be attached to an EC2 <tt>Instance</tt>.
- Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-network-iface-embedded.html
- */
+ Constructs a {@code EC2NetworkInterface} to be attached to an EC2 {@link Instance}.
+
+ @see <a href=" https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-network-iface-embedded.html">Documentation Reference</a> */
 public class EC2NetworkInterface {
     private boolean associatePublicIpAddress;
     private boolean deleteOnTermination;

--- a/src/main/java/com/scaleset/cfbuilder/ec2/instance/EC2NetworkInterface.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/instance/EC2NetworkInterface.java
@@ -16,14 +16,14 @@ public class EC2NetworkInterface {
     private Boolean deleteOnTermination;
     private String description;
     private String deviceIndex;
-    private List<String> groupSet;
+    private List<Object> groupSet;
     private String networkInterfaceId;
-    private int ipv6AddressCount;
+    private Integer ipv6AddressCount;
     private List<Ipv6Address> ipv6Addresses;
     private String privateIpAddress;
     private List<PrivateIpAddressSpecification> privateIpAddresses;
-    private int secondaryPrivateIpAddressCount;
-    private String subnetId;
+    private Integer secondaryPrivateIpAddressCount;
+    private Object subnetId;
 
     public EC2NetworkInterface() {
         this.groupSet = new ArrayList<>();
@@ -83,20 +83,20 @@ public class EC2NetworkInterface {
         return this;
     }
 
-    public List<String> getGroupSet() {
+    public List<Object> getGroupSet() {
         return groupSet;
     }
 
-    public void setGroupSet(List<String> groupSet) {
+    public void setGroupSet(List<Object> groupSet) {
         this.groupSet = groupSet;
     }
 
-    public EC2NetworkInterface groupSet(List<String> groupSet) {
+    public EC2NetworkInterface groupSet(List<Object> groupSet) {
         this.groupSet = groupSet;
         return this;
     }
 
-    public EC2NetworkInterface addGroupSet(String groupID) {
+    public EC2NetworkInterface addGroupSet(Object groupID) {
         this.groupSet.add(groupID);
         return this;
     }
@@ -114,15 +114,15 @@ public class EC2NetworkInterface {
         return this;
     }
 
-    public int getIpv6AddressCount() {
+    public Integer getIpv6AddressCount() {
         return ipv6AddressCount;
     }
 
-    public void setIpv6AddressCount(int ipv6AddressCount) {
+    public void setIpv6AddressCount(Integer ipv6AddressCount) {
         this.ipv6AddressCount = ipv6AddressCount;
     }
 
-    public EC2NetworkInterface ipv6AddressCount(int ipv6AddressCount) {
+    public EC2NetworkInterface ipv6AddressCount(Integer ipv6AddressCount) {
         this.ipv6AddressCount = ipv6AddressCount;
         return this;
     }
@@ -176,29 +176,29 @@ public class EC2NetworkInterface {
         return this;
     }
 
-    public int getSecondaryPrivateIpAddressCount() {
+    public Integer getSecondaryPrivateIpAddressCount() {
         return secondaryPrivateIpAddressCount;
     }
 
-    public void setSecondaryPrivateIpAddressCount(int secondaryPrivateIpAddressCount) {
+    public void setSecondaryPrivateIpAddressCount(Integer secondaryPrivateIpAddressCount) {
         this.secondaryPrivateIpAddressCount = secondaryPrivateIpAddressCount;
     }
 
-    public EC2NetworkInterface secondaryPrivateIpAddressCount(int secondaryPrivateIpAddressCount) {
+    public EC2NetworkInterface secondaryPrivateIpAddressCount(Integer secondaryPrivateIpAddressCount) {
         this.secondaryPrivateIpAddressCount = secondaryPrivateIpAddressCount;
         return this;
     }
 
-    public String getSubnetId() {
+    public Object getSubnetId() {
         return subnetId;
     }
 
-    public EC2NetworkInterface subnetId(String subnetId) {
+    public EC2NetworkInterface subnetId(Object subnetId) {
         this.subnetId = subnetId;
         return this;
     }
 
-    public void setSubnetId(String subnetId) {
+    public void setSubnetId(Object subnetId) {
         this.subnetId = subnetId;
     }
 }

--- a/src/main/java/com/scaleset/cfbuilder/ec2/instance/EC2NetworkInterface.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/instance/EC2NetworkInterface.java
@@ -10,7 +10,7 @@ import com.scaleset.cfbuilder.ec2.networkinterface.PrivateIpAddressSpecification
 /**
  Constructs a {@code EC2NetworkInterface} to be attached to an EC2 {@link Instance}.
 
- @see <a href=" https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-network-iface-embedded.html">Documentation Reference</a> */
+ @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-network-iface-embedded.html">Documentation Reference</a> */
 public class EC2NetworkInterface {
     private boolean associatePublicIpAddress;
     private boolean deleteOnTermination;

--- a/src/main/java/com/scaleset/cfbuilder/ec2/instance/EC2NetworkInterface.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/instance/EC2NetworkInterface.java
@@ -1,0 +1,203 @@
+package com.scaleset.cfbuilder.ec2.instance;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.scaleset.cfbuilder.ec2.networkinterface.Ipv6Address;
+import com.scaleset.cfbuilder.ec2.networkinterface.PrivateIpAddressSpecification;
+
+/**
+ Constructs a <tt>EC2NetworkInterface</tt> to be attached to an EC2 <tt>Instance</tt>.
+ Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-network-iface-embedded.html
+ */
+public class EC2NetworkInterface {
+    private boolean associatePublicIpAddress;
+    private boolean deleteOnTermination;
+    private String description;
+    private String deviceIndex;
+    private List<String> groupSet;
+    private String networkInterfaceId;
+    private int ipv6AddressCount;
+    private List<Ipv6Address> ipv6Addresses;
+    private String privateIpAddress;
+    private List<PrivateIpAddressSpecification> privateIpAddresses;
+    private int secondaryPrivateIpAddressCount;
+    private String subnetId;
+
+    public EC2NetworkInterface() {
+        this.groupSet = new ArrayList<>();
+        this.ipv6Addresses = new ArrayList<>();
+        this.privateIpAddresses = new ArrayList<>();
+    }
+
+    public boolean isAssociatePublicIpAddress() {
+        return associatePublicIpAddress;
+    }
+
+    public void setAssociatePublicIpAddress(boolean associatePublicIpAddress) {
+        this.associatePublicIpAddress = associatePublicIpAddress;
+    }
+
+    public EC2NetworkInterface associatePublicIpAddress(boolean associatePublicIpAddress) {
+        this.associatePublicIpAddress = associatePublicIpAddress;
+        return this;
+    }
+
+    public boolean isDeleteOnTermination() {
+        return deleteOnTermination;
+    }
+
+    public void setDeleteOnTermination(boolean deleteOnTermination) {
+        this.deleteOnTermination = deleteOnTermination;
+    }
+
+    public EC2NetworkInterface deleteOnTermination(boolean deleteOnTermination) {
+        this.deleteOnTermination = deleteOnTermination;
+        return this;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public EC2NetworkInterface description(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public String getDeviceIndex() {
+        return deviceIndex;
+    }
+
+    public void setDeviceIndex(String deviceIndex) {
+        this.deviceIndex = deviceIndex;
+    }
+
+    public EC2NetworkInterface deviceIndex(String deviceIndex) {
+        this.deviceIndex = deviceIndex;
+        return this;
+    }
+
+    public List<String> getGroupSet() {
+        return groupSet;
+    }
+
+    public void setGroupSet(List<String> groupSet) {
+        this.groupSet = groupSet;
+    }
+
+    public EC2NetworkInterface groupSet(List<String> groupSet) {
+        this.groupSet = groupSet;
+        return this;
+    }
+
+    public EC2NetworkInterface addGroupSet(String groupID) {
+        this.groupSet.add(groupID);
+        return this;
+    }
+
+    public String getNetworkInterfaceId() {
+        return networkInterfaceId;
+    }
+
+    public void setNetworkInterfaceId(String networkInterfaceId) {
+        this.networkInterfaceId = networkInterfaceId;
+    }
+
+    public EC2NetworkInterface networkInterfaceId(String networkInterfaceId) {
+        this.networkInterfaceId = networkInterfaceId;
+        return this;
+    }
+
+    public int getIpv6AddressCount() {
+        return ipv6AddressCount;
+    }
+
+    public void setIpv6AddressCount(int ipv6AddressCount) {
+        this.ipv6AddressCount = ipv6AddressCount;
+    }
+
+    public EC2NetworkInterface ipv6AddressCount(int ipv6AddressCount) {
+        this.ipv6AddressCount = ipv6AddressCount;
+        return this;
+    }
+
+    public List<Ipv6Address> getIpv6Addresses() {
+        return ipv6Addresses;
+    }
+
+    public void setIpv6Addresses(List<Ipv6Address> ipv6Addresses) {
+        this.ipv6Addresses = ipv6Addresses;
+    }
+
+    public EC2NetworkInterface ipv6Addresses(List<Ipv6Address> ipv6Addresses) {
+        this.ipv6Addresses = ipv6Addresses;
+        return this;
+    }
+
+    public EC2NetworkInterface addIpv6Addresses(Ipv6Address ipv6Address) {
+        this.ipv6Addresses.add(ipv6Address);
+        return this;
+    }
+
+    public String getPrivateIpAddress() {
+        return privateIpAddress;
+    }
+
+    public void setPrivateIpAddress(String privateIpAddress) {
+        this.privateIpAddress = privateIpAddress;
+    }
+
+    public EC2NetworkInterface privateIpAddress(String privateIpAddress) {
+        this.privateIpAddress = privateIpAddress;
+        return this;
+    }
+
+    public List<PrivateIpAddressSpecification> getPrivateIpAddresses() {
+        return privateIpAddresses;
+    }
+
+    public void setPrivateIpAddresses(List<PrivateIpAddressSpecification> privateIpAddresses) {
+        this.privateIpAddresses = privateIpAddresses;
+    }
+
+    public EC2NetworkInterface privateIpAddresses(List<PrivateIpAddressSpecification> privateIpAddresses) {
+        this.privateIpAddresses = privateIpAddresses;
+        return this;
+    }
+
+    public EC2NetworkInterface addPrivateIpAddresses(PrivateIpAddressSpecification privateIpAddressSpecification) {
+        privateIpAddresses.add(privateIpAddressSpecification);
+        return this;
+    }
+
+    public int getSecondaryPrivateIpAddressCount() {
+        return secondaryPrivateIpAddressCount;
+    }
+
+    public void setSecondaryPrivateIpAddressCount(int secondaryPrivateIpAddressCount) {
+        this.secondaryPrivateIpAddressCount = secondaryPrivateIpAddressCount;
+    }
+
+    public EC2NetworkInterface secondaryPrivateIpAddressCount(int secondaryPrivateIpAddressCount) {
+        this.secondaryPrivateIpAddressCount = secondaryPrivateIpAddressCount;
+        return this;
+    }
+
+    public String getSubnetId() {
+        return subnetId;
+    }
+
+    public EC2NetworkInterface subnetId(String subnetId) {
+        this.subnetId = subnetId;
+        return this;
+    }
+
+    public void setSubnetId(String subnetId) {
+        this.subnetId = subnetId;
+    }
+}

--- a/src/main/java/com/scaleset/cfbuilder/ec2/instance/ElasticGpuSpecification.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/instance/ElasticGpuSpecification.java
@@ -7,7 +7,7 @@ import com.scaleset.cfbuilder.ec2.Instance;
  <br>
  Property of the EC2 {@link Instance} resource.
 
- @see <a href=" https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-elasticgpuspecification.html">Documentation Reference</a> */
+ @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-elasticgpuspecification.html">Documentation Reference</a> */
 public class ElasticGpuSpecification {
     private String type;
 

--- a/src/main/java/com/scaleset/cfbuilder/ec2/instance/ElasticGpuSpecification.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/instance/ElasticGpuSpecification.java
@@ -1,0 +1,23 @@
+package com.scaleset.cfbuilder.ec2.instance;
+
+/**
+ Constructs a <tt>ElasticGpuSpecification</tt> to accelerate the graphics performance of your applications.
+ Property of the EC2 <tt>Instance</tt> resource.
+ Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-elasticgpuspecification.html
+ */
+public class ElasticGpuSpecification {
+    private String type;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public ElasticGpuSpecification type(String type) {
+        this.type = type;
+        return this;
+    }
+}

--- a/src/main/java/com/scaleset/cfbuilder/ec2/instance/ElasticGpuSpecification.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/instance/ElasticGpuSpecification.java
@@ -1,10 +1,13 @@
 package com.scaleset.cfbuilder.ec2.instance;
 
+import com.scaleset.cfbuilder.ec2.Instance;
+
 /**
- Constructs a <tt>ElasticGpuSpecification</tt> to accelerate the graphics performance of your applications.
- Property of the EC2 <tt>Instance</tt> resource.
- Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-elasticgpuspecification.html
- */
+ Constructs a {@code ElasticGpuSpecification} to accelerate the graphics performance of your applications.
+ <br>
+ Property of the EC2 {@link Instance} resource.
+
+ @see <a href=" https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-elasticgpuspecification.html">Documentation Reference</a> */
 public class ElasticGpuSpecification {
     private String type;
 

--- a/src/main/java/com/scaleset/cfbuilder/ec2/instance/SSMAssociation.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/instance/SSMAssociation.java
@@ -3,13 +3,15 @@ package com.scaleset.cfbuilder.ec2.instance;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.scaleset.cfbuilder.ec2.Instance;
 import com.scaleset.cfbuilder.ec2.instance.ssmassociation.AssociationParameter;
 
 /**
- Constructs a <tt>SSMAssociation</tt> to specify a Amazon EC2 Systems Manager (SSM) document and parameter values.
- Property of EC2 <tt>Instance</tt>.
- Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-ssmassociations.html
- */
+ Constructs a {@code SSMAssociation} to specify a Amazon EC2 Systems Manager (SSM) document and parameter values.
+ <br>
+ Property of EC2 {@link Instance}.
+
+ @see <a href=" https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-ssmassociations.html">Documentation Reference</a> */
 public class SSMAssociation {
     private List<AssociationParameter> associationParameters;
     private String documentName;
@@ -31,7 +33,7 @@ public class SSMAssociation {
         return this;
     }
 
-    public SSMAssociation addAssociationParameters(AssociationParameter associationParameter){
+    public SSMAssociation addAssociationParameters(AssociationParameter associationParameter) {
         this.associationParameters.add(associationParameter);
         return this;
     }

--- a/src/main/java/com/scaleset/cfbuilder/ec2/instance/SSMAssociation.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/instance/SSMAssociation.java
@@ -11,7 +11,7 @@ import com.scaleset.cfbuilder.ec2.instance.ssmassociation.AssociationParameter;
  <br>
  Property of EC2 {@link Instance}.
 
- @see <a href=" https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-ssmassociations.html">Documentation Reference</a> */
+ @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-ssmassociations.html">Documentation Reference</a> */
 public class SSMAssociation {
     private List<AssociationParameter> associationParameters;
     private String documentName;

--- a/src/main/java/com/scaleset/cfbuilder/ec2/instance/SSMAssociation.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/instance/SSMAssociation.java
@@ -1,0 +1,51 @@
+package com.scaleset.cfbuilder.ec2.instance;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.scaleset.cfbuilder.ec2.instance.ssmassociation.AssociationParameter;
+
+/**
+ Constructs a <tt>SSMAssociation</tt> to specify a Amazon EC2 Systems Manager (SSM) document and parameter values.
+ Property of EC2 <tt>Instance</tt>.
+ Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-ssmassociations.html
+ */
+public class SSMAssociation {
+    private List<AssociationParameter> associationParameters;
+    private String documentName;
+
+    public SSMAssociation() {
+        this.associationParameters = new ArrayList<>();
+    }
+
+    public List<AssociationParameter> getAssociationParameters() {
+        return associationParameters;
+    }
+
+    public void setAssociationParameters(List<AssociationParameter> associationParameters) {
+        this.associationParameters = associationParameters;
+    }
+
+    public SSMAssociation associationParameters(List<AssociationParameter> associationParameters) {
+        this.associationParameters = associationParameters;
+        return this;
+    }
+
+    public SSMAssociation addAssociationParameters(AssociationParameter associationParameter){
+        this.associationParameters.add(associationParameter);
+        return this;
+    }
+
+    public String getDocumentName() {
+        return documentName;
+    }
+
+    public void setDocumentName(String documentName) {
+        this.documentName = documentName;
+    }
+
+    public SSMAssociation documentName(String documentName) {
+        this.documentName = documentName;
+        return this;
+    }
+}

--- a/src/main/java/com/scaleset/cfbuilder/ec2/instance/ec2blockdevicemapping/EC2EBSBlockDevice.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/instance/ec2blockdevicemapping/EC2EBSBlockDevice.java
@@ -9,7 +9,7 @@ import com.scaleset.cfbuilder.ec2.instance.EC2BlockDeviceMapping;
 public class EC2EBSBlockDevice {
     private Boolean deleteOnTermination;
     private Boolean encrypted;
-    private int iops;
+    private Integer iops;
     private String snapshotId;
     private String volumeSize;
     private String volumeType;
@@ -40,15 +40,15 @@ public class EC2EBSBlockDevice {
         return this;
     }
 
-    public int getIops() {
+    public Integer getIops() {
         return iops;
     }
 
-    public void setIops(int iops) {
+    public void setIops(Integer iops) {
         this.iops = iops;
     }
 
-    public EC2EBSBlockDevice iops(int iops) {
+    public EC2EBSBlockDevice iops(Integer iops) {
         this.iops = iops;
         return this;
     }

--- a/src/main/java/com/scaleset/cfbuilder/ec2/instance/ec2blockdevicemapping/EC2EBSBlockDevice.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/instance/ec2blockdevicemapping/EC2EBSBlockDevice.java
@@ -1,0 +1,92 @@
+package com.scaleset.cfbuilder.ec2.instance.ec2blockdevicemapping;
+
+/**
+ Constructs a <tt>EC2EBSBlockDevice</tt> to be embedded in a <tt>EC2BlockDeviceMapping</tt>.
+ Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-blockdev-template.html
+ */
+public class EC2EBSBlockDevice {
+    private boolean deleteOnTermination;
+    private boolean encrypted;
+    private int iops;
+    private String snapshotId;
+    private String volumeSize;
+    private String volumeType;
+
+    public boolean isDeleteOnTermination() {
+        return deleteOnTermination;
+    }
+
+    public void setDeleteOnTermination(boolean deleteOnTermination) {
+        this.deleteOnTermination = deleteOnTermination;
+    }
+
+    public EC2EBSBlockDevice deleteOnTermination(boolean deleteOnTermination) {
+        this.deleteOnTermination = deleteOnTermination;
+        return this;
+    }
+
+    public boolean isEncrypted() {
+        return encrypted;
+    }
+
+    public void setEncrypted(boolean encrypted) {
+        this.encrypted = encrypted;
+    }
+
+    public EC2EBSBlockDevice encrypted(boolean encrypted) {
+        this.encrypted = encrypted;
+        return this;
+    }
+
+    public int getIops() {
+        return iops;
+    }
+
+    public void setIops(int iops) {
+        this.iops = iops;
+    }
+
+    public EC2EBSBlockDevice iops(int iops) {
+        this.iops = iops;
+        return this;
+    }
+
+    public String getSnapshotId() {
+        return snapshotId;
+    }
+
+    public void setSnapshotId(String snapshotId) {
+        this.snapshotId = snapshotId;
+    }
+
+    public EC2EBSBlockDevice snapshotId(String snapshotId) {
+        this.snapshotId = snapshotId;
+        return this;
+    }
+
+    public String getVolumeSize() {
+        return volumeSize;
+    }
+
+    public void setVolumeSize(String volumeSize) {
+        this.volumeSize = volumeSize;
+    }
+
+    public EC2EBSBlockDevice volumeSize(String volumeSize) {
+        this.volumeSize = volumeSize;
+        return this;
+    }
+
+    public String getVolumeType() {
+        return volumeType;
+    }
+
+    public void setVolumeType(String volumeType) {
+        this.volumeType = volumeType;
+    }
+
+    public EC2EBSBlockDevice volumeType(String volumeType) {
+        this.volumeType = volumeType;
+        return this;
+    }
+}

--- a/src/main/java/com/scaleset/cfbuilder/ec2/instance/ec2blockdevicemapping/EC2EBSBlockDevice.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/instance/ec2blockdevicemapping/EC2EBSBlockDevice.java
@@ -1,9 +1,11 @@
 package com.scaleset.cfbuilder.ec2.instance.ec2blockdevicemapping;
 
+import com.scaleset.cfbuilder.ec2.instance.EC2BlockDeviceMapping;
+
 /**
- Constructs a <tt>EC2EBSBlockDevice</tt> to be embedded in a <tt>EC2BlockDeviceMapping</tt>.
- Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-blockdev-template.html
- */
+ Constructs a {@code EC2EBSBlockDevice} to be embedded in a {@link EC2BlockDeviceMapping}.
+
+ @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-blockdev-template.html">Documentation Reference</a> */
 public class EC2EBSBlockDevice {
     private boolean deleteOnTermination;
     private boolean encrypted;

--- a/src/main/java/com/scaleset/cfbuilder/ec2/instance/ec2blockdevicemapping/EC2EBSBlockDevice.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/instance/ec2blockdevicemapping/EC2EBSBlockDevice.java
@@ -7,35 +7,35 @@ import com.scaleset.cfbuilder.ec2.instance.EC2BlockDeviceMapping;
 
  @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-blockdev-template.html">Documentation Reference</a> */
 public class EC2EBSBlockDevice {
-    private boolean deleteOnTermination;
-    private boolean encrypted;
+    private Boolean deleteOnTermination;
+    private Boolean encrypted;
     private int iops;
     private String snapshotId;
     private String volumeSize;
     private String volumeType;
 
-    public boolean isDeleteOnTermination() {
+    public Boolean isDeleteOnTermination() {
         return deleteOnTermination;
     }
 
-    public void setDeleteOnTermination(boolean deleteOnTermination) {
+    public void setDeleteOnTermination(Boolean deleteOnTermination) {
         this.deleteOnTermination = deleteOnTermination;
     }
 
-    public EC2EBSBlockDevice deleteOnTermination(boolean deleteOnTermination) {
+    public EC2EBSBlockDevice deleteOnTermination(Boolean deleteOnTermination) {
         this.deleteOnTermination = deleteOnTermination;
         return this;
     }
 
-    public boolean isEncrypted() {
+    public Boolean isEncrypted() {
         return encrypted;
     }
 
-    public void setEncrypted(boolean encrypted) {
+    public void setEncrypted(Boolean encrypted) {
         this.encrypted = encrypted;
     }
 
-    public EC2EBSBlockDevice encrypted(boolean encrypted) {
+    public EC2EBSBlockDevice encrypted(Boolean encrypted) {
         this.encrypted = encrypted;
         return this;
     }

--- a/src/main/java/com/scaleset/cfbuilder/ec2/instance/ssmassociation/AssociationParameter.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/instance/ssmassociation/AssociationParameter.java
@@ -10,7 +10,7 @@ import com.scaleset.cfbuilder.ec2.instance.SSMAssociation;
  <br>
  Property of EC2 Instance {@link SSMAssociation}.
 
- @see <a href=" https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-ssmassociations-associationparameters.html">Documentation Reference</a> */
+ @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-ssmassociations-associationparameters.html">Documentation Reference</a> */
 public class AssociationParameter {
     private String key;
     private List<String> value;

--- a/src/main/java/com/scaleset/cfbuilder/ec2/instance/ssmassociation/AssociationParameter.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/instance/ssmassociation/AssociationParameter.java
@@ -3,16 +3,19 @@ package com.scaleset.cfbuilder.ec2.instance.ssmassociation;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.scaleset.cfbuilder.ec2.instance.SSMAssociation;
+
 /**
- Constructs an <tt>AssociationParameter</tt> to specify input parameter values for an Amazon EC2 Systems Manager (SSM) document.
- Property of EC2 Instance <tt>SSMAssociation</tt>.
- Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-ssmassociations-associationparameters.html
- */
+ Constructs an {@code AssociationParameter} to specify input parameter values for an Amazon EC2 Systems Manager (SSM) document.
+ <br>
+ Property of EC2 Instance {@link SSMAssociation}.
+
+ @see <a href=" https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-ssmassociations-associationparameters.html">Documentation Reference</a> */
 public class AssociationParameter {
     private String key;
     private List<String> value;
 
-    public AssociationParameter(){
+    public AssociationParameter() {
         this.value = new ArrayList<>();
     }
 

--- a/src/main/java/com/scaleset/cfbuilder/ec2/instance/ssmassociation/AssociationParameter.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/instance/ssmassociation/AssociationParameter.java
@@ -1,0 +1,49 @@
+package com.scaleset.cfbuilder.ec2.instance.ssmassociation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ Constructs an <tt>AssociationParameter</tt> to specify input parameter values for an Amazon EC2 Systems Manager (SSM) document.
+ Property of EC2 Instance <tt>SSMAssociation</tt>.
+ Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-ssmassociations-associationparameters.html
+ */
+public class AssociationParameter {
+    private String key;
+    private List<String> value;
+
+    public AssociationParameter(){
+        this.value = new ArrayList<>();
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public AssociationParameter key(String key) {
+        this.key = key;
+        return this;
+    }
+
+    public List<String> getValue() {
+        return value;
+    }
+
+    public void setValue(List<String> value) {
+        this.value = value;
+    }
+
+    public AssociationParameter value(List<String> value) {
+        this.value = value;
+        return this;
+    }
+
+    public AssociationParameter addValue(String value) {
+        this.value.add(value);
+        return this;
+    }
+}

--- a/src/main/java/com/scaleset/cfbuilder/ec2/metadata/CFNFile.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/metadata/CFNFile.java
@@ -33,9 +33,9 @@ public class CFNFile {
     public String id;
 
     /**
-     Creates a <tt>CFNFile<tt> with the given id.
+     Creates a {@code CFNFile{@code  with the given id.
 
-     @param id for the <tt>CFNFile<tt> to be created
+     @param id for the {@code CFNFile{@code  to be created
      */
     public CFNFile(String id) {
         this.id = id;

--- a/src/main/java/com/scaleset/cfbuilder/ec2/networkinterface/Ipv6Address.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/networkinterface/Ipv6Address.java
@@ -5,7 +5,7 @@ import com.scaleset.cfbuilder.ec2.NetworkInterface;
 /**
  Constructs a {@code Ipv6Address} to associate with a {@link NetworkInterface}.
 
- @see <a href=" https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinterface-ipv6addresses.html">Documentation Reference</a> */
+ @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinterface-ipv6addresses.html">Documentation Reference</a> */
 public class Ipv6Address {
     private String ipv6Address;
 

--- a/src/main/java/com/scaleset/cfbuilder/ec2/networkinterface/Ipv6Address.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/networkinterface/Ipv6Address.java
@@ -1,9 +1,11 @@
 package com.scaleset.cfbuilder.ec2.networkinterface;
 
+import com.scaleset.cfbuilder.ec2.NetworkInterface;
+
 /**
- Constructs a <tt>Ipv6Address</tt> to associate with a <tt>NetworkInterface</tt>.
- Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinterface-ipv6addresses.html
- */
+ Constructs a {@code Ipv6Address} to associate with a {@link NetworkInterface}.
+
+ @see <a href=" https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinterface-ipv6addresses.html">Documentation Reference</a> */
 public class Ipv6Address {
     private String ipv6Address;
 

--- a/src/main/java/com/scaleset/cfbuilder/ec2/networkinterface/Ipv6Address.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/networkinterface/Ipv6Address.java
@@ -1,0 +1,22 @@
+package com.scaleset.cfbuilder.ec2.networkinterface;
+
+/**
+ Constructs a <tt>Ipv6Address</tt> to associate with a <tt>NetworkInterface</tt>.
+ Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-networkinterface-ipv6addresses.html
+ */
+public class Ipv6Address {
+    private String ipv6Address;
+
+    public String getIpv6Address() {
+        return ipv6Address;
+    }
+
+    public void setIpv6Address(String ipv6Address) {
+        this.ipv6Address = ipv6Address;
+    }
+
+    public Ipv6Address ipv6Address(String ipv6Address) {
+        this.ipv6Address = ipv6Address;
+        return this;
+    }
+}

--- a/src/main/java/com/scaleset/cfbuilder/ec2/networkinterface/PrivateIpAddressSpecification.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/networkinterface/PrivateIpAddressSpecification.java
@@ -10,7 +10,7 @@ public class PrivateIpAddressSpecification {
 
     private String privateIpAddress;
 
-    private boolean Primary;
+    private Boolean Primary;
 
     public String getPrivateIpAddress() {
         return privateIpAddress;
@@ -25,15 +25,15 @@ public class PrivateIpAddressSpecification {
         return this;
     }
 
-    public boolean isPrimary() {
+    public Boolean isPrimary() {
         return Primary;
     }
 
-    public void setPrimary(boolean primary) {
+    public void setPrimary(Boolean primary) {
         Primary = primary;
     }
 
-    public PrivateIpAddressSpecification primary(boolean primary) {
+    public PrivateIpAddressSpecification primary(Boolean primary) {
         Primary = primary;
         return this;
     }

--- a/src/main/java/com/scaleset/cfbuilder/ec2/networkinterface/PrivateIpAddressSpecification.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/networkinterface/PrivateIpAddressSpecification.java
@@ -1,9 +1,11 @@
 package com.scaleset.cfbuilder.ec2.networkinterface;
 
+import com.scaleset.cfbuilder.ec2.NetworkInterface;
+
 /**
- Constructs a <tt>PrivateIpAddressSpecification</tt> to be used in a <tt>Network Interface</tt>.
- Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-network-interface-privateipspec.html
- */
+ Constructs a {@code PrivateIpAddressSpecification} to be used in a {@link NetworkInterface}.
+
+ @see <a href=" https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-network-interface-privateipspec.html">Documentation Reference</a> */
 public class PrivateIpAddressSpecification {
 
     private String privateIpAddress;

--- a/src/main/java/com/scaleset/cfbuilder/ec2/networkinterface/PrivateIpAddressSpecification.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/networkinterface/PrivateIpAddressSpecification.java
@@ -1,0 +1,38 @@
+package com.scaleset.cfbuilder.ec2.networkinterface;
+
+/**
+ Constructs a <tt>PrivateIpAddressSpecification</tt> to be used in a <tt>Network Interface</tt>.
+ Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-network-interface-privateipspec.html
+ */
+public class PrivateIpAddressSpecification {
+
+    private String privateIpAddress;
+
+    private boolean Primary;
+
+    public String getPrivateIpAddress() {
+        return privateIpAddress;
+    }
+
+    public void setPrivateIpAddress(String privateIpAddress) {
+        this.privateIpAddress = privateIpAddress;
+    }
+
+    public PrivateIpAddressSpecification privateIpAddress(String privateIpAddress) {
+        this.privateIpAddress = privateIpAddress;
+        return this;
+    }
+
+    public boolean isPrimary() {
+        return Primary;
+    }
+
+    public void setPrimary(boolean primary) {
+        Primary = primary;
+    }
+
+    public PrivateIpAddressSpecification primary(boolean primary) {
+        Primary = primary;
+        return this;
+    }
+}

--- a/src/main/java/com/scaleset/cfbuilder/ec2/networkinterface/PrivateIpAddressSpecification.java
+++ b/src/main/java/com/scaleset/cfbuilder/ec2/networkinterface/PrivateIpAddressSpecification.java
@@ -5,7 +5,7 @@ import com.scaleset.cfbuilder.ec2.NetworkInterface;
 /**
  Constructs a {@code PrivateIpAddressSpecification} to be used in a {@link NetworkInterface}.
 
- @see <a href=" https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-network-interface-privateipspec.html">Documentation Reference</a> */
+ @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-network-interface-privateipspec.html">Documentation Reference</a> */
 public class PrivateIpAddressSpecification {
 
     private String privateIpAddress;

--- a/src/main/java/com/scaleset/cfbuilder/elasticloadbalancing/LoadBalancer.java
+++ b/src/main/java/com/scaleset/cfbuilder/elasticloadbalancing/LoadBalancer.java
@@ -3,6 +3,12 @@ package com.scaleset.cfbuilder.elasticloadbalancing;
 import com.scaleset.cfbuilder.annotations.Type;
 import com.scaleset.cfbuilder.core.Resource;
 
+/**
+ Constructs a {@code LoadBalancer} to create a LoadBalancer.
+ <br>
+ Type: {@code AWS::ElasticLoadBalancing::LoadBalancer}
+
+ @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb.html">Documentation Reference</a> */
 @Type("AWS::ElasticLoadBalancing::LoadBalancer")
 public interface LoadBalancer extends Resource {
 

--- a/src/main/java/com/scaleset/cfbuilder/iam/InstanceProfile.java
+++ b/src/main/java/com/scaleset/cfbuilder/iam/InstanceProfile.java
@@ -2,13 +2,15 @@ package com.scaleset.cfbuilder.iam;
 
 import com.scaleset.cfbuilder.annotations.Type;
 import com.scaleset.cfbuilder.core.Resource;
+import com.scaleset.cfbuilder.ec2.Instance;
 
 /**
- Constructs an <tt>InstanceProfile<tt> to create an AWS Identity and Access Management (IAM)
- instance profile that can be used with IAM roles for EC2 instances.
- Type: <tt>AWS::IAM::InstanceProfile<tt>
- Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-instanceprofile.html
- */
+ Constructs an {@code InstanceProfile} to create an AWS Identity and Access Management (IAM)
+ instance profile that can be used with IAM {@link Role}s for EC2 {@link Instance}s.
+ <br>
+ Type: {@code AWS::IAM::InstanceProfile}
+
+ @see <a href=" https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-instanceprofile.html">Documentation Reference</a> */
 @Type("AWS::IAM::InstanceProfile")
 public interface InstanceProfile extends Resource {
 

--- a/src/main/java/com/scaleset/cfbuilder/iam/InstanceProfile.java
+++ b/src/main/java/com/scaleset/cfbuilder/iam/InstanceProfile.java
@@ -10,7 +10,7 @@ import com.scaleset.cfbuilder.ec2.Instance;
  <br>
  Type: {@code AWS::IAM::InstanceProfile}
 
- @see <a href=" https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-instanceprofile.html">Documentation Reference</a> */
+ @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-instanceprofile.html">Documentation Reference</a> */
 @Type("AWS::IAM::InstanceProfile")
 public interface InstanceProfile extends Resource {
 

--- a/src/main/java/com/scaleset/cfbuilder/iam/Policies.java
+++ b/src/main/java/com/scaleset/cfbuilder/iam/Policies.java
@@ -1,4 +1,0 @@
-package com.scaleset.cfbuilder.iam;
-
-public class Policies {
-}

--- a/src/main/java/com/scaleset/cfbuilder/iam/Policy.java
+++ b/src/main/java/com/scaleset/cfbuilder/iam/Policy.java
@@ -4,10 +4,11 @@ import com.scaleset.cfbuilder.annotations.Type;
 import com.scaleset.cfbuilder.core.Resource;
 
 /**
- Constructs a <tt>Policy<tt> to associate an IAM policy with IAM users, roles, or groups.
- Type: <tt>AWS::IAM::Policy<tt>
- Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html
- */
+ Constructs a {@code Policy} to associate an IAM policy with IAM users, roles, or groups.
+ <br>
+ Type: {@code AWS::IAM::Policy}
+
+ @see <a href=" https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html">Documentation Reference</a> */
 @Type("AWS::IAM::Policy")
 public interface Policy extends Resource {
 

--- a/src/main/java/com/scaleset/cfbuilder/iam/Policy.java
+++ b/src/main/java/com/scaleset/cfbuilder/iam/Policy.java
@@ -8,7 +8,7 @@ import com.scaleset.cfbuilder.core.Resource;
  <br>
  Type: {@code AWS::IAM::Policy}
 
- @see <a href=" https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html">Documentation Reference</a> */
+ @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html">Documentation Reference</a> */
 @Type("AWS::IAM::Policy")
 public interface Policy extends Resource {
 

--- a/src/main/java/com/scaleset/cfbuilder/iam/PolicyDocument.java
+++ b/src/main/java/com/scaleset/cfbuilder/iam/PolicyDocument.java
@@ -3,15 +3,15 @@ package com.scaleset.cfbuilder.iam;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ Constructs a {@code PolicyDocument} representing an IAM policy to be used within {@link Policy} and {@link InstanceProfile}.
+
+ @see <a href=" https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies.html">Documentation Reference</a> */
 public class PolicyDocument {
     private String version;
     private String id;
     private List<Statement> statement;
 
-    /**
-     Constructs a <tt>PolicyDocument<tt> representing an IAM policy to be used within <tt>Policy<tt> and <tt>InstanceProfile<tt>.
-     Documentation: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies.html
-     */
     public PolicyDocument() {
         this.statement = new ArrayList<>();
     }

--- a/src/main/java/com/scaleset/cfbuilder/iam/PolicyDocument.java
+++ b/src/main/java/com/scaleset/cfbuilder/iam/PolicyDocument.java
@@ -6,7 +6,7 @@ import java.util.List;
 /**
  Constructs a {@code PolicyDocument} representing an IAM policy to be used within {@link Policy} and {@link InstanceProfile}.
 
- @see <a href=" https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies.html">Documentation Reference</a> */
+ @see <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies.html">Documentation Reference</a> */
 public class PolicyDocument {
     private String version;
     private String id;

--- a/src/main/java/com/scaleset/cfbuilder/iam/Principal.java
+++ b/src/main/java/com/scaleset/cfbuilder/iam/Principal.java
@@ -7,19 +7,18 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+/**
+ Constructs a {@code Principal} to specify the user (IAM user, federated user, or assumed-role user), AWS account,
+ AWS service, or other principal entity that is allowed or denied access to a resource.
+ <br>
+ Can be used as a IAM policy {@link Statement}.
+
+ @see <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html">Documentation Reference</a> */
 public class Principal {
 
     @JsonIgnore
     private Map<String, List<String>> principalMap;
 
-    /**
-     Constructs a {@code Principal} to specify the user (IAM user, federated user, or assumed-role user), AWS account,
-     AWS service, or other principal entity that is allowed or denied access to a resource.
-     <br>
-     Can be used as a IAM policy {@link Statement}.
-
-     @see <a href=" https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html">Documentation Reference</a>
-     */
     public Principal() {
         this.principalMap = new HashMap<>();
     }

--- a/src/main/java/com/scaleset/cfbuilder/iam/Principal.java
+++ b/src/main/java/com/scaleset/cfbuilder/iam/Principal.java
@@ -13,10 +13,12 @@ public class Principal {
     private Map<String, List<String>> principalMap;
 
     /**
-     Constructs a <tt>Principal<tt> to specify the user (IAM user, federated user, or assumed-role user), AWS account,
+     Constructs a {@code Principal} to specify the user (IAM user, federated user, or assumed-role user), AWS account,
      AWS service, or other principal entity that is allowed or denied access to a resource.
-     Can be used as a IAM policy <tt>Statement<tt>.
-     Documentation: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html
+     <br>
+     Can be used as a IAM policy {@link Statement}.
+
+     @see <a href=" https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html">Documentation Reference</a>
      */
     public Principal() {
         this.principalMap = new HashMap<>();

--- a/src/main/java/com/scaleset/cfbuilder/iam/Role.java
+++ b/src/main/java/com/scaleset/cfbuilder/iam/Role.java
@@ -4,10 +4,11 @@ import com.scaleset.cfbuilder.annotations.Type;
 import com.scaleset.cfbuilder.core.Resource;
 
 /**
- Constructs a <tt>Role<tt> to enable applications running on an EC2 instance to securely access AWS resources.
- Type: <tt>AWS::IAM::Role<tt>
- Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html
- */
+ Constructs a {@code Role} to enable applications running on an EC2 instance to securely access AWS resources.
+ <br>
+ Type: {@code AWS::IAM::Role}
+
+ @see <a href=" https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html">Documentation Reference</a> */
 @Type("AWS::IAM::Role")
 public interface Role extends Resource {
 

--- a/src/main/java/com/scaleset/cfbuilder/iam/Role.java
+++ b/src/main/java/com/scaleset/cfbuilder/iam/Role.java
@@ -8,7 +8,7 @@ import com.scaleset.cfbuilder.core.Resource;
  <br>
  Type: {@code AWS::IAM::Role}
 
- @see <a href=" https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html">Documentation Reference</a> */
+ @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html">Documentation Reference</a> */
 @Type("AWS::IAM::Role")
 public interface Role extends Resource {
 

--- a/src/main/java/com/scaleset/cfbuilder/iam/Statement.java
+++ b/src/main/java/com/scaleset/cfbuilder/iam/Statement.java
@@ -6,7 +6,7 @@ import java.util.List;
 /**
  Constructs a {@code Statement}  to build IAM policies in the {@link PolicyDocument}.
 
- @see <a href=" https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_statement.html">Documentation Reference</a> */
+ @see <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_statement.html">Documentation Reference</a> */
 public class Statement {
     private String sid;
     private List<String> action;

--- a/src/main/java/com/scaleset/cfbuilder/iam/Statement.java
+++ b/src/main/java/com/scaleset/cfbuilder/iam/Statement.java
@@ -3,6 +3,10 @@ package com.scaleset.cfbuilder.iam;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ Constructs a {@code Statement}  to build IAM policies in the {@link PolicyDocument}.
+
+ @see <a href=" https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_statement.html">Documentation Reference</a> */
 public class Statement {
     private String sid;
     private List<String> action;
@@ -14,10 +18,6 @@ public class Statement {
     private List<String> notResource;
     private Object condition;
 
-    /**
-     Constructs a <tt>Statement<tt> to build IAM policies in the <tt>PolicyDocument<tt>.
-     Documentation: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_statement.html
-     */
     public Statement() {
         this.action = new ArrayList<>();
         this.notAction = new ArrayList<>();

--- a/src/main/java/com/scaleset/cfbuilder/iam/User.java
+++ b/src/main/java/com/scaleset/cfbuilder/iam/User.java
@@ -4,10 +4,11 @@ import com.scaleset.cfbuilder.annotations.Type;
 import com.scaleset.cfbuilder.core.Resource;
 
 /**
- Constructs a <tt>User<tt> to create a user in your CloudFormation template.
- Type: <tt>AWS::IAM::User<tt>
- Documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-user.html
- */
+ Constructs a {@code User} to create a user in your CloudFormation template.
+ <br>
+ Type: {@code AWS::IAM::User}
+
+ @see <a href=" https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-user.html">Documentation Reference</a> */
 @Type("AWS::IAM::User")
 public interface User extends Resource {
 

--- a/src/main/java/com/scaleset/cfbuilder/iam/User.java
+++ b/src/main/java/com/scaleset/cfbuilder/iam/User.java
@@ -8,7 +8,7 @@ import com.scaleset.cfbuilder.core.Resource;
  <br>
  Type: {@code AWS::IAM::User}
 
- @see <a href=" https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-user.html">Documentation Reference</a> */
+ @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-user.html">Documentation Reference</a> */
 @Type("AWS::IAM::User")
 public interface User extends Resource {
 

--- a/src/main/java/com/scaleset/cfbuilder/rds/DBInstance.java
+++ b/src/main/java/com/scaleset/cfbuilder/rds/DBInstance.java
@@ -4,6 +4,12 @@ import com.scaleset.cfbuilder.annotations.Type;
 import com.scaleset.cfbuilder.core.Taggable;
 import com.scaleset.cfbuilder.ec2.SecurityGroup;
 
+/**
+ Constructs a {@code DBInstance} to create an Amazon Relational Database Service (Amazon RDS) DB instance.
+ <br>
+ Type: {@code AWS::RDS::DBInstance}
+
+ @see <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html">Documentation Reference</a> */
 @Type("AWS::RDS::DBInstance")
 public interface DBInstance extends Taggable {
 
@@ -27,5 +33,4 @@ public interface DBInstance extends Taggable {
         tag("Name", name);
         return this;
     }
-
 }

--- a/src/main/java/com/scaleset/cfbuilder/rds/DBInstance.java
+++ b/src/main/java/com/scaleset/cfbuilder/rds/DBInstance.java
@@ -23,7 +23,7 @@ public interface DBInstance extends Taggable {
 
     DBInstance dBInstanceClass(String dBInstanceClass);
 
-    DBInstance allocatedStorage(int allocatedStorage);
+    DBInstance allocatedStorage(Integer allocatedStorage);
 
     DBInstance storageType(String storageType);
 

--- a/src/test/java/com/scaleset/cfbuilder/MetadataTest.java
+++ b/src/test/java/com/scaleset/cfbuilder/MetadataTest.java
@@ -121,7 +121,7 @@ public class MetadataTest {
                     .path("/")
                     .assumeRolePolicyDocument("PolicyContent");
 
-            List resourceList = new ArrayList<>();
+            List<String> resourceList = new ArrayList<>();
             resourceList.add("ec2.amazonaws.com");
 
             Principal principal = new Principal().principal("Service", resourceList);

--- a/src/test/java/com/scaleset/cfbuilder/TemplateTest.java
+++ b/src/test/java/com/scaleset/cfbuilder/TemplateTest.java
@@ -51,7 +51,6 @@ public class TemplateTest extends Assert {
             Object keyName = template.ref("KeyName");
             Object imageId = template.ref("ImageId");
             Object az = template.ref("MyAZ");
-            Object instanceProfile = ref("InstanceProfile");
             Object vpcId = template.ref("VpcId");
 
             SecurityGroup securityGroup = resource(SecurityGroup.class, "SecurityGroup")
@@ -71,7 +70,6 @@ public class TemplateTest extends Assert {
                     .availabilityZone(az)
                     .keyName(keyName)
                     .imageId(imageId)
-                    .instanceProfile(instanceProfile)
                     .instanceType(instanceType)
                     .securityGroupIds(securityGroup);
 

--- a/src/test/java/com/scaleset/cfbuilder/ec2/Ec2Test.java
+++ b/src/test/java/com/scaleset/cfbuilder/ec2/Ec2Test.java
@@ -1,0 +1,197 @@
+package com.scaleset.cfbuilder.ec2;
+
+import com.scaleset.cfbuilder.core.Fn;
+import com.scaleset.cfbuilder.core.Module;
+import com.scaleset.cfbuilder.core.Tag;
+import com.scaleset.cfbuilder.core.Template;
+import com.scaleset.cfbuilder.ec2.instance.EC2NetworkInterface;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ Test templates using all {@code AWS::EC2} types built with the cloudformation builder.
+ Examples taken from <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/quickref-ec2.html">here</a>.
+ */
+public class Ec2Test {
+    private String expectedVpcInstanceWithEniTemplateString = "---\n" +
+            "AWSTemplateFormatVersion: \"2010-09-09\"\n" +
+            "Resources:\n" +
+            "  ControlPortAddress:\n" +
+            "    Type: \"AWS::EC2::EIP\"\n" +
+            "    Properties:\n" +
+            "      Domain: \"vpc\"\n" +
+            "  Ec2Instance:\n" +
+            "    Type: \"AWS::EC2::Instance\"\n" +
+            "    Properties:\n" +
+            "      ImageId:\n" +
+            "        Fn::FindInMap:\n" +
+            "        - \"RegionMap\"\n" +
+            "        - Ref: \"'AWS::Region'\"\n" +
+            "        - \"AMI\"\n" +
+            "      KeyName:\n" +
+            "        Ref: \"KeyName\"\n" +
+            "      NetworkInterfaces: []\n" +
+            "      UserData:\n" +
+            "        Fn::Base64:\n" +
+            "          Fn::Join:\n" +
+            "          - \"\"\n" +
+            "          - - \"#!/bin/bash -xe\"\n" +
+            "            - \"yum install ec2-net-utils -y\"\n" +
+            "            - \"ec2ifup eth1\"\n" +
+            "            - \"service httpd start\"\n" +
+            "      Tags:\n" +
+            "      - Value: \"Role\"\n" +
+            "        Key: \"Key\"\n" +
+            "      - Value: \"Test Instance\"\n" +
+            "        Key: \"Value\"\n" +
+            "  AssociateControlPort:\n" +
+            "    Type: \"AWS::EC2::EIPAssociation\"\n" +
+            "    Properties:\n" +
+            "      AllocationId:\n" +
+            "        Fn::GetAtt:\n" +
+            "        - \"ControlPortAddress\"\n" +
+            "        - \"AllocationId\"\n" +
+            "      NetworkInterfaceId:\n" +
+            "        Ref: \"controlXface\"\n" +
+            "  controlXface:\n" +
+            "    Type: \"AWS::EC2::NetworkInterface\"\n" +
+            "    Properties:\n" +
+            "      SubnetId:\n" +
+            "        Ref: \"SubnetId\"\n" +
+            "      Description: \"Interace for controlling traffic such as SSH\"\n" +
+            "      GroupSet:\n" +
+            "      - Ref: \"SSHSecurityGroup\"\n" +
+            "      SourceDestCheck: true\n" +
+            "      Tags:\n" +
+            "      - Value: \"Network\"\n" +
+            "        Key: \"Key\"\n" +
+            "      - Value: \"Control\"\n" +
+            "        Key: \"Value\"\n" +
+            "  SSHSecurityGroup:\n" +
+            "    Type: \"AWS::EC2::SecurityGroup\"\n" +
+            "    Properties:\n" +
+            "      VpcId:\n" +
+            "        Ref: \"VpcId\"\n" +
+            "      GroupDescription: \"Enable SSH access via port 22\"\n" +
+            "      SecurityGroupIngress:\n" +
+            "      - IpProtocol: \"tcp\"\n" +
+            "        CidrIp: \"0.0.0.0/0\"\n" +
+            "        FromPort: 22\n" +
+            "        ToPort: 22\n" +
+            "      - IpProtocol: \"tcp\"\n" +
+            "        CidrIp: \"0.0.0.0/0\"\n" +
+            "        FromPort: 22\n" +
+            "        ToPort: 22\n" +
+            "  webXface:\n" +
+            "    Type: \"AWS::EC2::NetworkInterface\"\n" +
+            "    Properties:\n" +
+            "      SubnetId:\n" +
+            "        Ref: \"SubNetId\"\n" +
+            "      Description: \"Interface for controlling traffic such as SSH\"\n" +
+            "      GroupSet:\n" +
+            "      - Ref: \"WebSecurityGroup\"\n" +
+            "      SourceDestCheck: true\n" +
+            "      Tags:\n" +
+            "      - Value: \"Network\"\n" +
+            "        Key: \"Key\"\n" +
+            "      - Value: \"Web\"\n" +
+            "        Key: \"Value\"\n" +
+            "  WebSecurityGroup:\n" +
+            "    Type: \"AWS::EC2::SecurityGroup\"\n" +
+            "    Properties:\n" +
+            "      VpcId:\n" +
+            "        Ref: \"VpcId\"\n" +
+            "      GroupDescription: \"Enable HTTP access via user defined port\"\n" +
+            "      SecurityGroupIngress:\n" +
+            "      - IpProtocol: \"tcp\"\n" +
+            "        CidrIp: \"0.0.0.0/0\"\n" +
+            "        FromPort: 80\n" +
+            "        ToPort: 80\n" +
+            "      - IpProtocol: \"tcp\"\n" +
+            "        CidrIp: \"0.0.0.0/0\"\n" +
+            "        FromPort: 80\n" +
+            "        ToPort: 80\n" +
+            "  WebPortAddress:\n" +
+            "    Type: \"AWS::EC2::EIP\"\n" +
+            "    Properties:\n" +
+            "      Domain: \"vpc\"\n" +
+            "  AssociateWebPort:\n" +
+            "    Type: \"AWS::EC2::EIPAssociation\"\n" +
+            "    Properties:\n" +
+            "      AllocationId:\n" +
+            "        Fn::GetAtt:\n" +
+            "        - \"WebPortAddress\"\n" +
+            "        - \"AllocationId\"\n" +
+            "      NetworkInterfaceId:\n" +
+            "        Ref: \"webXface\"\n";
+
+    @Test
+    public void vpcInstanceWithEni() {
+        Template vpcInstanceWithEniTemplate = new Template();
+        new VpcInstanceWithEniModule().id("").template(vpcInstanceWithEniTemplate).build();
+        String vpcInstanceWithEniTemplateString = vpcInstanceWithEniTemplate.toString(true);
+
+        assertNotNull(vpcInstanceWithEniTemplate);
+        assertEquals(expectedVpcInstanceWithEniTemplateString, vpcInstanceWithEniTemplateString);
+        System.err.println(vpcInstanceWithEniTemplateString);
+    }
+
+    class VpcInstanceWithEniModule extends Module {
+        private String userDataString = "!Sub |\n" +
+                "          #!/bin/bash -xe\n" +
+                "          yum install ec2-net-utils -y\n" +
+                "          ec2ifup eth1\n" +
+                "          service httpd start";
+
+        public void build() {
+            resource(Eip.class, "ControlPortAddress")
+                    .domain("vpc");
+            resource(EipAssociation.class, "AssociateControlPort")
+                    .allocationId(fnGetAtt("ControlPortAddress", "AllocationId"))
+                    .networkInterfaceId(ref("controlXface"));
+            resource(Eip.class, "WebPortAddress")
+                    .domain("vpc");
+            resource(EipAssociation.class, "AssociateWebPort")
+                    .allocationId(fnGetAtt("WebPortAddress", "AllocationId"))
+                    .networkInterfaceId(ref("webXface"));
+            resource(SecurityGroup.class, "SSHSecurityGroup")
+                    .vpcId(ref("VpcId"))
+                    .groupDescription("Enable SSH access via port 22")
+                    .ingress(ingress -> ingress.cidrIp("0.0.0.0/0"), "tcp", 22, 22);
+            resource(SecurityGroup.class, "WebSecurityGroup")
+                    .vpcId(ref("VpcId"))
+                    .groupDescription("Enable HTTP access via user defined port")
+                    .ingress(ingress -> ingress.cidrIp("0.0.0.0/0"), "tcp", 80, 80);
+            resource(NetworkInterface.class, "controlXface")
+                    .subnetId(ref("SubnetId"))
+                    .description("Interace for controlling traffic such as SSH")
+                    .groupSet(ref("SSHSecurityGroup"))
+                    .sourceDestCheck(true)
+                    .tags(new Tag("Key", "Network"), new Tag("Value", "Control"));
+            resource(NetworkInterface.class, "webXface")
+                    .subnetId(ref("SubNetId"))
+                    .description("Interface for controlling traffic such as SSH")
+                    .groupSet(ref("WebSecurityGroup"))
+                    .sourceDestCheck(true)
+                    .tags(new Tag("Key", "Network"), new Tag("Value", "Web"));
+            EC2NetworkInterface networkInterfaceA = new EC2NetworkInterface()
+                    .networkInterfaceId(ref("controlXface"))
+                    .deviceIndex("0");
+            EC2NetworkInterface networkInterfaceB = new EC2NetworkInterface()
+                    .networkInterfaceId(ref("webXface"))
+                    .deviceIndex("1");
+            resource(Instance.class, "Ec2Instance")
+                    .imageId(new Fn("FindInMap", "RegionMap", ref("'AWS::Region'"), "AMI"))
+                    .keyName(ref("KeyName"))
+                    .networkInterfaces()
+                    .userData(new UserData(Fn.fnDelimiter("Join", "",
+                            "#!/bin/bash -xe",
+                            "yum install ec2-net-utils -y",
+                            "ec2ifup eth1",
+                            "service httpd start")))
+                    .tags(new Tag("Key", "Role"), new Tag("Value", "Test Instance"));
+        }
+    }
+}

--- a/src/test/java/com/scaleset/cfbuilder/ec2/InstanceTest.java
+++ b/src/test/java/com/scaleset/cfbuilder/ec2/InstanceTest.java
@@ -1,22 +1,19 @@
 package com.scaleset.cfbuilder.ec2;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import com.scaleset.cfbuilder.core.Fn;
 import com.scaleset.cfbuilder.core.Module;
 import com.scaleset.cfbuilder.core.Template;
 import com.scaleset.cfbuilder.ec2.instance.EC2BlockDeviceMapping;
 import com.scaleset.cfbuilder.ec2.instance.EC2NetworkInterface;
 import com.scaleset.cfbuilder.ec2.instance.ec2blockdevicemapping.EC2EBSBlockDevice;
-import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  Test ec2 instance templates built with the cloudformation builder.
- Examples taken from <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html">here</a>.
+ Ec2withEbs and autoPubIP examples taken from <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html">here</a>.
  */
 public class InstanceTest {
     private String expectedEc2withEbsTemplateString = "---\n" +
@@ -106,7 +103,7 @@ public class InstanceTest {
     }
 
     class AutoPubIPModule extends Module {
-        public void build(){
+        public void build() {
             EC2NetworkInterface ec2NetworkInterface = new EC2NetworkInterface()
                     .associatePublicIpAddress(true)
                     .deviceIndex("0")
@@ -122,4 +119,11 @@ public class InstanceTest {
                     .networkInterfaces(ec2NetworkInterface);
         }
     }
+
+//    class fullInstanceModule extends Module {
+//        public void build() {
+//            resource(Instance.class, "FullInstance")
+//                    .affinity("")
+//        }
+//    }
 }

--- a/src/test/java/com/scaleset/cfbuilder/ec2/InstanceTest.java
+++ b/src/test/java/com/scaleset/cfbuilder/ec2/InstanceTest.java
@@ -3,9 +3,14 @@ package com.scaleset.cfbuilder.ec2;
 import com.scaleset.cfbuilder.core.Fn;
 import com.scaleset.cfbuilder.core.Module;
 import com.scaleset.cfbuilder.core.Template;
+import com.scaleset.cfbuilder.ec2.instance.CreditSpecification;
 import com.scaleset.cfbuilder.ec2.instance.EC2BlockDeviceMapping;
+import com.scaleset.cfbuilder.ec2.instance.EC2MountPoint;
 import com.scaleset.cfbuilder.ec2.instance.EC2NetworkInterface;
+import com.scaleset.cfbuilder.ec2.instance.ElasticGpuSpecification;
+import com.scaleset.cfbuilder.ec2.instance.SSMAssociation;
 import com.scaleset.cfbuilder.ec2.instance.ec2blockdevicemapping.EC2EBSBlockDevice;
+import com.scaleset.cfbuilder.ec2.instance.ssmassociation.AssociationParameter;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -78,6 +83,16 @@ public class InstanceTest {
         System.err.println(autoPubIPTemplateString);
     }
 
+    @Test
+    public void testProperties() {
+        Template testPropertiesTemplate = new Template();
+        new TestPropertiesModule().id("").template(testPropertiesTemplate).build();
+        String autoPubIPTemplateString = testPropertiesTemplate.toString(true);
+
+        assertNotNull(testPropertiesTemplate);
+        System.err.println(autoPubIPTemplateString);
+    }
+
     class Ec2withEbsModule extends Module {
         public void build() {
             this.template.setDescription("Ec2 block device mapping");
@@ -120,10 +135,39 @@ public class InstanceTest {
         }
     }
 
-//    class fullInstanceModule extends Module {
-//        public void build() {
-//            resource(Instance.class, "FullInstance")
-//                    .affinity("")
-//        }
-//    }
+    class TestPropertiesModule extends Module {
+        public void build() {
+            CreditSpecification creditSpecification = new CreditSpecification().cPUCredits("100");
+            creditSpecification.setcPUCredits(creditSpecification.getcPUCredits());
+            ElasticGpuSpecification elasticGpuSpecification = new ElasticGpuSpecification().type("abc");
+            elasticGpuSpecification.setType(elasticGpuSpecification.getType());
+            EC2EBSBlockDevice ec2EBSBlockDevice = new EC2EBSBlockDevice()
+                    .deleteOnTermination(false)
+                    .iops(199)
+                    .volumeSize("volumeSizeVal")
+                    .volumeType("volumeTypeVal")
+                    .encrypted(true)
+                    .snapshotId("snapshotIdVal");
+            EC2BlockDeviceMapping ec2BlockDeviceMapping = new EC2BlockDeviceMapping()
+                    .deviceName("deviceNameVal")
+                    .noDevice(false)
+                    .ebs(ec2EBSBlockDevice)
+                    .virtualName("virtualNameVal");
+            EC2MountPoint ec2MountPoint = new EC2MountPoint()
+                    .device("deviceVal")
+                    .volumeId("volumeIdVal");
+            AssociationParameter associationParameter = new AssociationParameter()
+                    .addValue("valueVal")
+                    .key("keyVal");
+            SSMAssociation ssmAssociation = new SSMAssociation()
+                    .documentName("documentNameVal")
+                    .addAssociationParameters(associationParameter);
+            resource(Instance.class, "Ec2Test")
+                    .creditSpecification(creditSpecification)
+                    .elasticGpuSpecifications(elasticGpuSpecification)
+                    .blockDeviceMappings(ec2BlockDeviceMapping)
+                    .volumes(ec2MountPoint)
+                    .ssmAssociations(ssmAssociation);
+        }
+    }
 }

--- a/src/test/java/com/scaleset/cfbuilder/ec2/InstanceTest.java
+++ b/src/test/java/com/scaleset/cfbuilder/ec2/InstanceTest.java
@@ -1,0 +1,125 @@
+package com.scaleset.cfbuilder.ec2;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.scaleset.cfbuilder.core.Fn;
+import com.scaleset.cfbuilder.core.Module;
+import com.scaleset.cfbuilder.core.Template;
+import com.scaleset.cfbuilder.ec2.instance.EC2BlockDeviceMapping;
+import com.scaleset.cfbuilder.ec2.instance.EC2NetworkInterface;
+import com.scaleset.cfbuilder.ec2.instance.ec2blockdevicemapping.EC2EBSBlockDevice;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ Test ec2 instance templates built with the cloudformation builder.
+ Examples taken from <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html">here</a>.
+ */
+public class InstanceTest {
+    private String expectedEc2withEbsTemplateString = "---\n" +
+            "AWSTemplateFormatVersion: \"2010-09-09\"\n" +
+            "Description: \"Ec2 block device mapping\"\n" +
+            "Resources:\n" +
+            "  MyEC2Instance:\n" +
+            "    Type: \"AWS::EC2::Instance\"\n" +
+            "    Properties:\n" +
+            "      ImageId: \"ami-79fd7eee\"\n" +
+            "      KeyName: \"testkey\"\n" +
+            "      BlockDeviceMappings:\n" +
+            "      - DeviceName: \"/dev/sdm\"\n" +
+            "        Ebs:\n" +
+            "          DeleteOnTermination: false\n" +
+            "          Iops: 200\n" +
+            "          VolumeSize: \"20\"\n" +
+            "          VolumeType: \"io1\"\n" +
+            "      - DeviceName: \"/dev/sdk\"\n" +
+            "        NoDevice: false\n";
+
+    private String expectedAutoPubIPTemplateString = "---\n" +
+            "AWSTemplateFormatVersion: \"2010-09-09\"\n" +
+            "Resources:\n" +
+            "  Ec2Instance:\n" +
+            "    Type: \"AWS::EC2::Instance\"\n" +
+            "    Properties:\n" +
+            "      ImageId:\n" +
+            "        Fn::FindInMap:\n" +
+            "        - \"RegionMap\"\n" +
+            "        - Ref: \"AWS::Region\"\n" +
+            "        - \"AMI\"\n" +
+            "      KeyName:\n" +
+            "        Ref: \"KeyName\"\n" +
+            "      NetworkInterfaces:\n" +
+            "      - AssociatePublicIpAddress: true\n" +
+            "        DeviceIndex: \"0\"\n" +
+            "        GroupSet:\n" +
+            "        - Ref: \"myVPCEC2SecurityGroup\"\n" +
+            "        SubnetId:\n" +
+            "          Ref: \"PublicSubnet\"\n";
+
+    @Test
+    public void ec2withEbs() {
+        Template ec2withEbsTemplate = new Template();
+        new Ec2withEbsModule().id("").template(ec2withEbsTemplate).build();
+        String ec2withEbsTemplateString = ec2withEbsTemplate.toString(true);
+
+        assertNotNull(ec2withEbsTemplate);
+        assertEquals(expectedEc2withEbsTemplateString, ec2withEbsTemplateString);
+        System.err.println(ec2withEbsTemplateString);
+    }
+
+    @Test
+    public void autoPubIP() {
+        Template autoPubIPTemplate = new Template();
+        new AutoPubIPModule().id("").template(autoPubIPTemplate).build();
+        String autoPubIPTemplateString = autoPubIPTemplate.toString(true);
+
+        assertNotNull(autoPubIPTemplate);
+        assertEquals(expectedAutoPubIPTemplateString, autoPubIPTemplateString);
+        System.err.println(autoPubIPTemplateString);
+    }
+
+    class Ec2withEbsModule extends Module {
+        public void build() {
+            this.template.setDescription("Ec2 block device mapping");
+
+            EC2EBSBlockDevice ec2EBSBlockDeviceA = new EC2EBSBlockDevice()
+                    .volumeType("io1")
+                    .iops(200)
+                    .deleteOnTermination(false)
+                    .volumeSize("20");
+            EC2BlockDeviceMapping ec2BlockDeviceMappingA = new EC2BlockDeviceMapping()
+                    .deviceName("/dev/sdm")
+                    .ebs(ec2EBSBlockDeviceA);
+
+            EC2BlockDeviceMapping ec2BlockDeviceMappingB = new EC2BlockDeviceMapping()
+                    .deviceName("/dev/sdk")
+                    .noDevice(false);
+
+            resource(Instance.class, "MyEC2Instance")
+                    .imageId("ami-79fd7eee")
+                    .keyName("testkey")
+                    .blockDeviceMappings(ec2BlockDeviceMappingA, ec2BlockDeviceMappingB);
+        }
+    }
+
+    class AutoPubIPModule extends Module {
+        public void build(){
+            EC2NetworkInterface ec2NetworkInterface = new EC2NetworkInterface()
+                    .associatePublicIpAddress(true)
+                    .deviceIndex("0")
+                    .addGroupSet(ref("myVPCEC2SecurityGroup"))
+                    .subnetId(ref("PublicSubnet"));
+
+            resource(Instance.class, "Ec2Instance")
+                    .imageId(new Fn("FindInMap",
+                            "RegionMap",
+                            ref("AWS::Region"),
+                            "AMI"))
+                    .keyName(ref("KeyName"))
+                    .networkInterfaces(ec2NetworkInterface);
+        }
+    }
+}

--- a/src/test/java/com/scaleset/cfbuilder/ec2/InstanceTest.java
+++ b/src/test/java/com/scaleset/cfbuilder/ec2/InstanceTest.java
@@ -162,6 +162,11 @@ public class InstanceTest {
             SSMAssociation ssmAssociation = new SSMAssociation()
                     .documentName("documentNameVal")
                     .addAssociationParameters(associationParameter);
+            resource(SecurityGroupIngress.class, "SecurityGroupIngressName")
+                    .cidrIp("cidrIpVal")
+                    .groupName("grouNameVal")
+                    .sourceSecurityGroupName("sourceSecurityGroupNameVal")
+                    .sourceSecurityGroupOwnerId("sourceSecurityGroupOwnerIdVal");
             resource(Instance.class, "Ec2Test")
                     .creditSpecification(creditSpecification)
                     .elasticGpuSpecifications(elasticGpuSpecification)

--- a/src/test/java/com/scaleset/cfbuilder/ec2/NetworkInterfaceTest.java
+++ b/src/test/java/com/scaleset/cfbuilder/ec2/NetworkInterfaceTest.java
@@ -1,0 +1,43 @@
+package com.scaleset.cfbuilder.ec2;
+
+import com.scaleset.cfbuilder.core.Module;
+import com.scaleset.cfbuilder.core.Template;
+import com.scaleset.cfbuilder.ec2.networkinterface.Ipv6Address;
+import com.scaleset.cfbuilder.ec2.networkinterface.PrivateIpAddressSpecification;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+public class NetworkInterfaceTest {
+
+    @Test
+    public void testNetworkInterface() {
+        Template testNetworkInterfaceTemplate = new Template();
+        new TestNetworkInterfaceModule().id("").template(testNetworkInterfaceTemplate).build();
+        String testNetworkInterfaceTemplateString = testNetworkInterfaceTemplate.toString(true);
+
+        assertNotNull(testNetworkInterfaceTemplate);
+        System.err.println(testNetworkInterfaceTemplateString);
+    }
+
+    class TestNetworkInterfaceModule extends Module {
+        public void build() {
+            Ipv6Address ipv6Address = new Ipv6Address()
+                    .ipv6Address("ipv6AddressVal");
+            PrivateIpAddressSpecification privateIpAddressSpecification = new PrivateIpAddressSpecification()
+                    .privateIpAddress("privateIpAddressVal")
+                    .primary(true);
+            resource(NetworkInterface.class, "NetworkInterfaceName")
+                    .sourceDestCheck(true)
+                    .groupSet("groupSetVal")
+                    .description("descriptionVal")
+                    .subnetId("subnetIdVal")
+                    .name("nameVal")
+                    .privateIpAddress("privateIpAddressVal")
+                    .secondaryPrivateIpAddressCount(1)
+                    .ipv6AddressCount(1)
+                    .ipv6Addresses()
+                    .privateIpAddresses();
+        }
+    }
+}

--- a/src/test/java/com/scaleset/cfbuilder/ec2/VolumeTest.java
+++ b/src/test/java/com/scaleset/cfbuilder/ec2/VolumeTest.java
@@ -1,0 +1,94 @@
+package com.scaleset.cfbuilder.ec2;
+
+import com.scaleset.cfbuilder.core.Fn;
+import com.scaleset.cfbuilder.core.Module;
+import com.scaleset.cfbuilder.core.Tag;
+import com.scaleset.cfbuilder.core.Template;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ Test ec2 volumes templates built with the cloudformation builder.
+ Examples taken from <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ebs-volume.html">here</a>.
+ */
+public class VolumeTest {
+    private String expectedEncEbsSnapTemplateString = "---\n" +
+            "AWSTemplateFormatVersion: \"2010-09-09\"\n" +
+            "Resources:\n" +
+            "  NewVolume:\n" +
+            "    Type: \"AWS::EC2::Volume\"\n" +
+            "    Properties:\n" +
+            "      Size: 100\n" +
+            "      Encrypted: true\n" +
+            "      AvailabilityZone:\n" +
+            "        Fn::GetAtt:\n" +
+            "        - \"Ec2Instance\"\n" +
+            "        - \"AvailabilityZone\"\n" +
+            "      Tags:\n" +
+            "      - Value: \"MyTag\"\n" +
+            "        Key: \"Key\"\n" +
+            "      - Value: \"TagValue\"\n" +
+            "        Key: \"Value\"\n";
+
+    private String expectedEbs100IopsTemplateString = "---\n" +
+            "AWSTemplateFormatVersion: \"2010-09-09\"\n" +
+            "Resources:\n" +
+            "  NewVolume:\n" +
+            "    Type: \"AWS::EC2::Volume\"\n" +
+            "    Properties:\n" +
+            "      Size: 100\n" +
+            "      VolumeType: \"io1\"\n" +
+            "      Iops: 100\n" +
+            "      AvailabilityZone:\n" +
+            "        Fn::GetAtt:\n" +
+            "        - \"EC2Instance\"\n" +
+            "        - \"AvailabilityZone\"\n";
+
+    @Test
+    public void encEbsSnap() {
+        Template EncEbsSnapTemplate = new Template();
+        new EncEbsSnapModule().id("").template(EncEbsSnapTemplate).build();
+        String EncEbsSnapTemplateString = EncEbsSnapTemplate.toString(true);
+
+        assertNotNull(EncEbsSnapTemplate);
+        assertEquals(expectedEncEbsSnapTemplateString, EncEbsSnapTemplateString);
+        System.err.println(EncEbsSnapTemplateString);
+    }
+
+    @Test
+    public void ebs100Iops() {
+        Template Ebs100IopsTemplate = new Template();
+        new Ebs100IopsModule().id("").template(Ebs100IopsTemplate).build();
+        String Ebs100IopsTemplateString = Ebs100IopsTemplate.toString(true);
+
+        assertNotNull(Ebs100IopsTemplate);
+        assertEquals(expectedEbs100IopsTemplateString, Ebs100IopsTemplateString);
+        System.err.println(Ebs100IopsTemplateString);
+    }
+
+    class EncEbsSnapModule extends Module {
+        public void build() {
+            resource(Volume.class, "NewVolume")
+                    .size(100)
+                    .encrypted(true)
+                    .availabilityZone(new Fn("GetAtt",
+                            "Ec2Instance",
+                            "AvailabilityZone"))
+                    .tags(new Tag("Key", "MyTag"),
+                            new Tag("Value", "TagValue"));
+        }
+    }
+
+    class Ebs100IopsModule extends Module {
+        public void build() {
+            resource(Volume.class, "NewVolume")
+                    .size(100)
+                    .volumeType("io1")
+                    .iops(100)
+                    .availabilityZone(new Fn("GetAtt",
+                            "EC2Instance",
+                            "AvailabilityZone"));
+        }
+    }
+}

--- a/src/test/java/com/scaleset/cfbuilder/ec2/VolumeTest.java
+++ b/src/test/java/com/scaleset/cfbuilder/ec2/VolumeTest.java
@@ -6,7 +6,8 @@ import com.scaleset.cfbuilder.core.Tag;
 import com.scaleset.cfbuilder.core.Template;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  Test ec2 volumes templates built with the cloudformation builder.
@@ -67,6 +68,16 @@ public class VolumeTest {
         System.err.println(Ebs100IopsTemplateString);
     }
 
+    @Test
+    public void volumeTest() {
+        Template volumeTestTemplate = new Template();
+        new VolumeTestModule().id("").template(volumeTestTemplate).build();
+        String volumeTestTemplateString = volumeTestTemplate.toString(true);
+
+        assertNotNull(volumeTestTemplate);
+        System.err.println(volumeTestTemplateString);
+    }
+
     class EncEbsSnapModule extends Module {
         public void build() {
             resource(Volume.class, "NewVolume")
@@ -89,6 +100,15 @@ public class VolumeTest {
                     .availabilityZone(new Fn("GetAtt",
                             "EC2Instance",
                             "AvailabilityZone"));
+        }
+    }
+
+    class VolumeTestModule extends Module {
+        public void build() {
+            resource(Volume.class, "VolumeName")
+                    .autoEnableIO(true)
+                    .kmsKeyId("kmsKeyIdVal")
+                    .snapshotId("snapshotIdVal");
         }
     }
 }

--- a/src/test/java/com/scaleset/cfbuilder/iam/IamTest.java
+++ b/src/test/java/com/scaleset/cfbuilder/iam/IamTest.java
@@ -1,0 +1,48 @@
+package com.scaleset.cfbuilder.iam;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.scaleset.cfbuilder.core.Module;
+import com.scaleset.cfbuilder.core.Template;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+public class IamTest {
+    @Test
+    public void testIam() {
+        Template testIamTemplate = new Template();
+        new TestIamModule().id("").template(testIamTemplate).build();
+        String testIamTemplateString = testIamTemplate.toString(true);
+
+        assertNotNull(testIamTemplate);
+        System.err.println(testIamTemplateString);
+    }
+
+    class TestIamModule extends Module {
+        public void build() {
+            List<String> resourceList = new ArrayList<>();
+            resourceList.add("resourceVal");
+            Principal principal = new Principal()
+                    .principal("arnVal", resourceList);
+            Statement statement = new Statement()
+                    .addAction("actionVal")
+                    .addResource("resourceVal")
+                    .addNotAction("notActionVal")
+                    .addNotResource("notResourceVal")
+                    .principal(principal)
+                    .notPrincipal(principal);
+            PolicyDocument policyDocument = new PolicyDocument()
+                    .version("versionVal")
+                    .id("idVal")
+                    .addStatement(statement);
+            resource(Policy.class, "PolicyName")
+                    .groups("groupVal1", "groupVal2")
+                    .roles("roleVal1")
+                    .users("userVal1")
+                    .policyName("policyNameVal")
+                    .policyDocument(policyDocument);
+        }
+    }
+}

--- a/src/test/java/com/scaleset/cfbuilder/iam/IamTest.java
+++ b/src/test/java/com/scaleset/cfbuilder/iam/IamTest.java
@@ -32,7 +32,10 @@ public class IamTest {
                     .addNotAction("notActionVal")
                     .addNotResource("notResourceVal")
                     .principal(principal)
-                    .notPrincipal(principal);
+                    .notPrincipal(principal)
+                    .effect("effectVal")
+                    .sid("sidVal")
+                    .conditon("conditionVal");
             PolicyDocument policyDocument = new PolicyDocument()
                     .version("versionVal")
                     .id("idVal")


### PR DESCRIPTION
Extends the `AWS::EC2::Instance`, `AWS::EC2::NetworkInterface` and `AWS::EC2::Volume` types and adds all their possible properties and property types.

Also solves #20.

Progress:
- [x] Instance
- [x] NetworkInterface
- [x] Volume